### PR TITLE
chore: switch all references of graycore/github-actions-magento2 to mage-os/github-actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 # $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 #  
-# The configuration for Code Owners for graycoreio/magento2-github-actions.
+# The configuration for Code Owners for mgae-os/github-actions.
 #
 #  For more info see: https://help.github.com/articles/about-codeowners/
 #

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## PR Checklist
 Please check if your PR fulfills the following requirements:
 
-- [ ] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
+- [ ] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 

--- a/.github/workflows/_internal-install.yaml
+++ b/.github/workflows/_internal-install.yaml
@@ -47,5 +47,5 @@ jobs:
         composer_version: ${{ matrix.composer }}
         php_version: ${{ matrix.php }}
         magento_version: ${{ matrix.magento }}
-        package_name: graycore/magento2-demo-package
+        package_name: mage-os/magento2-demo-package
         source_folder: $GITHUB_WORKSPACE/_test/demo-package

--- a/.github/workflows/_internal-integration.yaml
+++ b/.github/workflows/_internal-integration.yaml
@@ -37,8 +37,8 @@ jobs:
     needs: compute_matrix
     uses: ./.github/workflows/integration.yaml
     with:
-      package_name: graycore/magento2-demo-package
+      package_name: mage-os/magento2-demo-package
       source_folder: $GITHUB_WORKSPACE/_test/demo-package
       matrix: ${{ needs.compute_matrix.outputs.matrix }}
-      test_command: ../../../vendor/bin/phpunit ../../../vendor/graycore/magento2-demo-package/Test/Integration
+      test_command: ../../../vendor/bin/phpunit ../../../vendor/mage-os/magento2-demo-package/Test/Integration
       fail-fast: false

--- a/.github/workflows/_internal-setup-magento.yaml
+++ b/.github/workflows/_internal-setup-magento.yaml
@@ -93,7 +93,7 @@ jobs:
         mode: store
         working-directory: ${{ env.magento_folder }}
     
-    - uses: graycoreio/github-actions-magento2/cache-magento@main
+    - uses: mage-os/github-actions/cache-magento@main
       with:
         mode: 'store'
         composer_cache_key:  '${{ matrix.magento }}'
@@ -116,7 +116,7 @@ jobs:
         mode: extension
         magento_version: magento/project-community-edition:2.4.5-p1
 
-    - uses: graycoreio/github-actions-magento2/cache-magento@main
+    - uses: mage-os/github-actions/cache-magento@main
       with:
         mode: 'extension'
         composer_cache_key: 'magento/project-community-edition:2.4.5-p1'

--- a/.github/workflows/integration-README.md
+++ b/.github/workflows/integration-README.md
@@ -24,7 +24,7 @@ See the [integration.yaml](./integration.yaml)
 
 ###  Matrix Format
 
-The Magento matrix format outlined by the [supported versions action.](https://github.com/graycoreio/github-actions-magento2/tree/main/supported-version/supported.json) 
+The Magento matrix format outlined by the [supported versions action.](https://github.com/mage-os/github-actions/tree/main/supported-version/supported.json) 
 
 
 ## Usage
@@ -47,12 +47,12 @@ jobs:
         matrix: ${{ steps.supported-version.outputs.matrix }}
       steps:
         - uses: actions/checkout@v2
-        - uses: graycoreio/github-actions-magento2/supported-version@main
+        - uses: mage-os/github-actions/supported-version@main
           id: supported-version
         - run: echo ${{ steps.supported-version.outputs.matrix }}
   integration-workflow:
     needs: compute_matrix
-    uses: graycoreio/github-actions-magento2/.github/workflows/integration.yaml@main
+    uses: mage-os/github-actions/.github/workflows/integration.yaml@main
     with:
       package_name: my-vendor/package
       matrix: ${{ needs.compute_matrix.outputs.matrix }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -108,7 +108,7 @@ jobs:
         COMPOSER_AUTH: ${{ secrets.composer_auth }}
       name: Create Magento ${{ matrix.magento }} Project 
 
-    - uses: graycoreio/github-actions-magento2/get-magento-version@main
+    - uses: mage-os/github-actions/get-magento-version@main
       id: magento-version
       with:
         working-directory:  ${{ inputs.magento_directory }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -35,7 +35,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project lead at [damien@graycore.io](mailto:damien@graycore.io). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project lead at [board@mage-os.org](mailto:board@mage-os.org). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,9 @@ Help us keep "Github Actions for Magento 2" open and inclusive. Please read and 
 
 ## <a name="question"></a> Got a Question or Problem?
 
-Do not open issues for general support questions as we want to keep GitHub issues for bug reports and feature requests. You've got much better chances of getting your question answered on [Discussions](https://github.com/graycoreio/github-actions-magento2/discussions).
+Do not open issues for general support questions as we want to keep GitHub issues for bug reports and feature requests. You've got much better chances of getting your question answered on [Discussions](https://github.com/mage-os/github-actions/discussions).
 
-To save your and our time, we will systematically close all issues that are requests for general support and redirect people to [Discussions](https://github.com/graycoreio/github-actions-magento2/discussions).
+To save your and our time, we will systematically close all issues that are requests for general support and redirect people to [Discussions](https://github.com/mage-os/github-actions/discussions).
 
 ## <a name="issue"></a> Found a Bug?
 If you find a bug in the source code, you can help us by
@@ -54,15 +54,15 @@ We will be insisting on a minimal reproduce scenario in order to save maintainer
 
 Unfortunately, we are not able to investigate / fix bugs without a minimal reproduction, so if we don't hear back from you we are going to close an issue that doesn't have enough info to be reproduced.
 
-You can file new issues by filling out our [new issue form](https://github.com/graycoreio/github-actions-magento2/issues/new/choose).
+You can file new issues by filling out our [new issue form](https://github.com/mage-os/github-actions/issues/new/choose).
 
 
 ### <a name="submit-pr"></a> Submitting a Pull Request (PR)
 Before you submit your Pull Request (PR) consider the following guidelines:
 
-1. Search [GitHub](https://github.com/graycoreio/github-actions-magento2/pulls) for an open or closed PR
+1. Search [GitHub](https://github.com/mage-os/github-actions/pulls) for an open or closed PR
   that relates to your submission. You don't want to duplicate effort.
-1. Fork the [graycoreio/github-actions-magento2](https://github.com/graycoreio/github-actions-magento2) repo.
+1. Fork the [mage-os/github-actions](https://github.com/mage-os/github-actions) repo.
 1. Make your changes in a new git branch:
 
      ```shell
@@ -161,7 +161,7 @@ to read on GitHub as well as in various git tools.
 
 The footer should contain a [closing reference to an issue](https://help.github.com/articles/closing-issues-via-commit-messages/) if any.
 
-Samples: (even more [samples](https://github.com/graycoreio/github-actions-magento2/commits/main))
+Samples: (even more [samples](https://github.com/mage-os/github-actions/commits/main))
 
 ```
 docs(changelog): update changelog to beta.5
@@ -217,7 +217,7 @@ reference GitHub issues that this commit **Closes**.
 A detailed explanation can be found in this [document][commit-message-format].
 
 
-[coc]: https://github.com/graycoreio/github-actions-magento2/code-of-conduct/blob/main/CODE_OF_CONDUCT.md
+[coc]: https://github.com/mage-os/github-actions/code-of-conduct/blob/main/CODE_OF_CONDUCT.md
 [commit-message-format]: https://www.conventionalcommits.org/en/v1.0.0/
-[github]: https://github.com/graycoreio/github-actions-magento2
-[discussions]: https://github.com/graycoreio/github-actions-magento2/discussions
+[github]: https://github.com/mage-os/github-actions
+[discussions]: https://github.com/mage-os/github-actions/discussions

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 <div align="center">
 
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/graycoreio/github-actions-magento2)
-[![Unit Test](https://github.com/graycoreio/github-actions-magento2/actions/workflows/_internal-unit.yaml/badge.svg)](https://github.com/graycoreio/github-actions-magento2/actions/workflows/_internal-unit.yaml)
-[![Integration Test](https://github.com/graycoreio/github-actions-magento2/actions/workflows/_internal-integration.yaml/badge.svg)](https://github.com/graycoreio/github-actions-magento2/actions/workflows/_internal-integration.yaml)
-[![Installation Test](https://github.com/graycoreio/github-actions-magento2/actions/workflows/_internal-install.yaml/badge.svg)](https://github.com/graycoreio/github-actions-magento2/actions/workflows/_internal-install.yaml)
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/mage-os/github-actions-magento2)
+[![Unit Test](https://github.com/mage-os/github-actions/actions/workflows/_internal-unit.yaml/badge.svg)](https://github.com/mage-os/github-actions/actions/workflows/_internal-unit.yaml)
+[![Integration Test](https://github.com/mage-os/github-actions/actions/workflows/_internal-integration.yaml/badge.svg)](https://github.com/mage-os/github-actions/actions/workflows/_internal-integration.yaml)
+[![Installation Test](https://github.com/mage-os/github-actions/actions/workflows/_internal-install.yaml/badge.svg)](https://github.com/mage-os/github-actions/actions/workflows/_internal-install.yaml)
 
 </div>
 

--- a/_test/demo-package/composer.json
+++ b/_test/demo-package/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "graycore/magento2-demo-package",
+    "name": "mage-os/magento2-demo-package",
     "description": "A Magento 2 Demostration Package",
     "type": "magento2-module",
     "license": "MIT",

--- a/cache-magento/README.md
+++ b/cache-magento/README.md
@@ -9,7 +9,7 @@ See the [action.yml](./action.yml)
 
 | Input              | Description                                                                            | Required | Default      |
 | ------------------ | -------------------------------------------------------------------------------------- | -------- | ------------ |
-| composer_cache_key | A key to version the composer cache. Can be incremented if you need to bust the cache. | false    | '__graycore' |
+| composer_cache_key | A key to version the composer cache. Can be incremented if you need to bust the cache. | false    | '__mageos' |
 | mode               | "The mode for setup, one of: `extension` or `store`."                                  | true     | N/A          |
 | magento_directory  | The Magento directory for the action to run against.                                   | true     | N/A          |
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: graycoreio/github-actions-magento2/cache-magento@main
+    - uses: mage-os/github-actions/cache-magento@main
       with:
         magento_directory: $GITHUB_WORKSPACE 
         mode: 'store'

--- a/cache-magento/action.yml
+++ b/cache-magento/action.yml
@@ -5,7 +5,7 @@ description: "A Github Action that creates a composer cache for a Magento extens
 inputs:
   composer_cache_key:
     required: false
-    default: "__graycore"
+    default: "__mageos"
     description: A key to version the composer cache. Can be incremented if you need to bust the cache.
 
   mode:

--- a/coding-standard/README.md
+++ b/coding-standard/README.md
@@ -23,7 +23,7 @@ jobs:
   coding-standard:
     runs-on: ubuntu-latest
     steps:
-    - uses: graycoreio/github-actions-magento2/coding-standard@main
+    - uses: mage-os/github-actions/coding-standard@main
       with:
         version: 25 # Optional, will use the latest if omitted.
         path: app/code # Optional, will be used when event is not a pull request.

--- a/fix-magento-install/README.md
+++ b/fix-magento-install/README.md
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: graycoreio/github-actions-magento2/fix-magento-install@main
+    - uses: mage-os/github-actions/fix-magento-install@main
       with:
         magento_directory: path/to/magento
 ```

--- a/fix-magento-install/action.yml
+++ b/fix-magento-install/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: graycoreio/github-actions-magento2/get-magento-version@main
+    - uses: mage-os/github-actions/get-magento-version@main
       id: init-magento-get-magento-version
       with:
         working-directory: ${{ inputs.magento_directory }}

--- a/get-magento-version/README.md
+++ b/get-magento-version/README.md
@@ -25,7 +25,7 @@ jobs:
     name: A job to compute an installed Magento version.
     steps:
       - uses: actions/checkout@v3
-      - uses: graycoreio/github-actions-magento2/get-magento-version@main
+      - uses: mage-os/github-actions/get-magento-version@main
         id: get-magento-version
       - run: echo version ${{ steps.get-magento-version.outputs.version }}
         shell: bash

--- a/installation-test/README.md
+++ b/installation-test/README.md
@@ -26,7 +26,7 @@ jobs:
       matrix: ${{ steps.supported-version.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
-      - uses: graycoreio/github-actions-magento2/supported-version@main
+      - uses: mage-os/github-actions/supported-version@main
         id: supported-version
       - run: echo ${{ steps.supported-version.outputs.matrix }}
 
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: graycoreio/github-actions-magento2/installation-test@main
+    - uses: mage-os/github-actions/installation-test@main
       with:
         composer_version: ${{ matrix.composer }}
         php_version: ${{ matrix.php }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@graycore/github-actions-magento",
+  "name": "@mage-os/github-actions",
   "version": "1.3.0",
   "description": "Github Actions for Magento 2",
   "scripts": {
@@ -9,14 +9,14 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/graycoreio/github-actions-magento2.git"
+    "url": "git+https://github.com/mage-os/github-actions.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/graycoreio/github-actions-magento2/issues"
+    "url": "https://github.com/mage-os/github-actions/issues"
   },
-  "homepage": "https://github.com/graycoreio/github-actions-magento2#readme",
+  "homepage": "https://github.com/mage-os/github-actions#readme",
   "dependencies": {
     "@actions/core": "^1.10.0"
   },

--- a/setup-magento/action.yml
+++ b/setup-magento/action.yml
@@ -84,7 +84,7 @@ runs:
       name: Create Magento ${{ inputs.magento_version }} Project
       if: inputs.mode == 'extension'
 
-    - uses: graycoreio/github-actions-magento2/fix-magento-install@main
+    - uses: mage-os/github-actions/fix-magento-install@main
       name: Fix Magento Out of Box Install Issues
       with:
         magento_directory: ${{ steps.setup-magento-compute-directory.outputs.MAGENTO_DIRECTORY }}

--- a/supported-version/README.md
+++ b/supported-version/README.md
@@ -41,7 +41,7 @@ jobs:
     outputs:
       matrix: ${{ steps.supported-version.outputs.matrix }}
     steps:
-      - uses: graycoreio/github-actions-magento2/supported-version@main
+      - uses: mage-os/github-actions/supported-version@main
         id: supported-version
       - run: echo ${{ steps.supported-version.outputs.matrix }}
 ```

--- a/supported-version/package.json
+++ b/supported-version/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@graycore/github-actions-magento2-supported-version",
+  "name": "@mage-os/github-actions-supported-version",
   "version": "1.0.0",
   "description": "A Github Action that computes the currently supported Github Actions Matrix for Magento 2 Versions",
   "main": "index.js",

--- a/unit-test/README.md
+++ b/unit-test/README.md
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: graycoreio/github-actions-magento2/unit-test@main
+    - uses: mage-os/github-actions/unit-test@main
       with:
         php_version: ${{ matrix.php_version }}
         composer_auth: ${{ secrets.COMPOSER_AUTH }}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/github-actions-magento2/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Previously many of the actions and instructions references the original `graycode/github-actions-magento2´, causing inconsistencies.

## What is the new behavior?
Actions and workflows reference the matching versions inside the `mage-os/github-actions` repo.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
