### PR TITLE
fix: make es8 run correctly in integration tests

### DIFF
--- a/.github/workflows/_internal-integration.yaml
+++ b/.github/workflows/_internal-integration.yaml
@@ -42,4 +42,3 @@ jobs:
       matrix: ${{ needs.compute_matrix.outputs.matrix }}
       test_command: ../../../vendor/bin/phpunit ../../../vendor/mage-os/magento2-demo-package/Test/Integration
       fail-fast: false
-      magento_repository: https://preview-mirror.mage-os.org/

--- a/.github/workflows/_internal-integration.yaml
+++ b/.github/workflows/_internal-integration.yaml
@@ -42,3 +42,4 @@ jobs:
       matrix: ${{ needs.compute_matrix.outputs.matrix }}
       test_command: ../../../vendor/bin/phpunit ../../../vendor/mage-os/magento2-demo-package/Test/Integration
       fail-fast: false
+      magento_repository: https://preview-mirror.mage-os.org/

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -67,8 +67,8 @@ jobs:
         image: ${{ matrix.elasticsearch }}
         env:
           # By default, ElasticSearch refuses to spawn in single node configuration, as it expects redundancy.
-          discovery.type: single-node
           # This is a dev environment, so redundancy is just wasteful.
+          discovery.type: single-node
           # Disable HTTPS and password authentication
           # this is a local dev environment, so the added CA chain complexity is an extreme overkill
           xpack.security.enabled: false

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -66,7 +66,15 @@ jobs:
       elasticsearch:
         image: ${{ matrix.elasticsearch }}
         env:
+          # By default, ElasticSearch refuses to spawn in single node configuration, as it expects redundancy.
           discovery.type: single-node
+          # This is a dev environment, so redundancy is just wasteful.
+          # Disable HTTPS and password authentication
+          # this is a local dev environment, so the added CA chain complexity is an extreme overkill
+          xpack.security.enabled: false
+          xpack.security.http.ssl.enabled: false
+          xpack.security.transport.ssl.enabled: false
+
         options: >-
           --health-cmd "curl http://localhost:9200/_cluster/health"
           --health-interval 10s


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, es8 doesn't run at all in integration tests because of the HTTPS requirements by default. 

Fixes: N/A


## What is the new behavior?
We no longer run ES w/ Security enabled by default in CI.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

@ocramius has a Gitlab comment here https://gitlab.com/gitlab-org/gitlab-foss/-/issues/42214 about the settings. Finding these via simple Google search was rather difficult.
