### PR TITLE
chore: save test sandbox as an artifact to help debug failures

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -187,3 +187,12 @@ jobs:
     - run: ${{ inputs.test_command }}
       working-directory:  ${{ inputs.magento_directory }}/dev/tests/integration
       name: Run Integration Tests
+
+    - name: Upload test sandbox dir
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: sandbox-data
+        path: /home/runner/work/infrastructure/magento2/dev/tests/integration/tmp/sandbox-*
+        retention-days: 3
+


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the [integration tests for 2.3.7-p3 and 2.3.7-p4](https://github.com/mage-os/infrastructure/actions/runs/5349578846/jobs/9700998362) are failing while running the command

```
mysqldump --defaults-file='/home/runner/work/infrastructure/magento2/dev/tests/integration/tmp/sandbox-0-b2d2b01ad0d78dc7445b895482ac2363a73a5160365972260144dc0fcf0db84b/defaults_extra.cnf' --host='127.0.0.1' --port='3306' 'magento_integration_tests' > '/home/runner/work/infrastructure/magento2/dev/tests/integration/tmp/sandbox-0-b2d2b01ad0d78dc7445b895482ac2363a73a5160365972260144dc0fcf0db84b/setup_dump_magento_integration_tests.sql' 2>&1
```
The stack trace only shows something went wrong, but the actual failure message (if there is one) is piped into the `setup_dump_magento_integration_tests.sql'` and lost after the job completes.

## What is the new behavior?

In case of a failure, the sandbox contents are stored as an artifact which can be inspected to help debug.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
