### PR TITLE
Fix PHPcs baseline test failure when there are no files to check

### DIFF
--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -76,7 +76,7 @@ runs:
         echo "No files relevant to PHPCS have changed. Skipping PHPCS run."
         echo "List all the files that have changed: ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }}"
 
-    - name: Run step if test file(s) change
+    - name: Inform if relevant files have changed
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash
       run: |

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -64,8 +64,12 @@ runs:
           app:
             - '**/*.php'
             - '**/*.phtml'
+            - '**/*.graphqls'
+            - '**/*.less'
+            - '**/*.css'
             - '**/*.html'
             - '**/*.xml'
+            - '**/*.js'
 
     - name: Inform if no files have changed
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'false'

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -48,6 +48,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Debug
+      shell: bash
+      run: |
+        echo "Comparing ${{github.event.pull_request.head.repo.full_name}}:${{github.event.pull_request.head.ref}} to ${{github.event.pull_request.base.repo.full_name}}:${{github.event.pull_request.base.ref}}"
+
     - name: Checkout head
       uses: actions/checkout@v4
       with:
@@ -69,20 +74,20 @@ runs:
             - '**/*.xml'
             - '**/*.js'
 
-    - name: Checkout base
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'false'
-      uses: actions/checkout@v4
-      with:
-          ref: ${{github.event.pull_request.base.ref}}
-          repository: ${{github.event.pull_request.base.repo.full_name}}
-          path: base
-
     - name: Inform if no files have changed
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'false'
       shell: bash
       run: |
         echo "No files relevant to PHPCS have changed. Skipping PHPCS run."
         echo "List all the files that have changed: ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }}"
+
+    - name: Checkout base
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
+      uses: actions/checkout@v4
+      with:
+          ref: ${{github.event.pull_request.base.ref}}
+          repository: ${{github.event.pull_request.base.repo.full_name}}
+          path: base
 
     - name: Run step if test file(s) change
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -53,7 +53,36 @@ runs:
       with:
         fetch-depth: 0
 
+    - name: Get all changed files
+      uses: tj-actions/changed-files@v39
+      id: changed-files-phpcs
+      with:
+        write_output_files: true
+        output_dir: ${{ github.workspace }}
+        separator: " "
+        files_yaml: |
+          app:
+            - '**/*.php'
+            - '**/*.phtml'
+            - '**/*.html'
+            - '**/*.xml'
+
+    - name: Inform if no files have changed
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'false'
+      shell: bash
+      run: |
+        echo "No files relevant to PHPCS have changed. Skipping PHPCS run."
+        echo "List all the files that have changed: ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }}"
+
+    - name: Run step if test file(s) change
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
+      shell: bash
+      run: |
+        echo "One or more files relevant to PHPCS have changed."
+        echo "List all the files that have changed: ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }}"
+
     - name: Set PHP Version
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ inputs.php_version }}
@@ -61,6 +90,7 @@ runs:
         coverage: none
 
     - name: Install Coding Standard && Codesniffer baseline
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash
       run: |
         git config --global advice.detachedHead false
@@ -69,25 +99,13 @@ runs:
         composer require --dev "digitalrevolution/php-codesniffer-baseline: ${{ github.event.inputs.baseline_version || '*' }}"
 
     - name: Register Coding Standard
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash
       run: vendor/bin/phpcs --config-set installed_paths ${{ github.workspace }}/vendor/magento/magento-coding-standard,${{ github.workspace }}/vendor/phpcompatibility/php-compatibility
 
-    - name: Get all changed files
-      uses: tj-actions/changed-files@v37
-      with:
-        write_output_files: true
-        output_dir: ${{ github.workspace }}
-        separator: " "
-
-    - name: Verify the contents of the modified_files.txt file
-      shell: bash
-      run: |
-        sed "s/ /\n/g" ${{ github.workspace }}/modified_files.txt > ${{ github.workspace }}/newline_file.txt
-        grep -iE "\.php|\.phtml|\.html|\.xml" ${{ github.workspace }}/newline_file.txt > ${{ github.workspace }}/phpcs_files.txt || /bin/true
-
     - name: Checkout - Before Merge
       shell: bash
-      if: test -s ${{ github.workspace }}/phpcs_files.txt
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       run: |
         if ${{ github.event_name == 'pull_request' }}; then
           git checkout ${{ github.event.pull_request.base.ref }}
@@ -95,27 +113,36 @@ runs:
           git checkout ${{ github.event.before }}
         fi
 
-    - name: Filter php files and execute phpcs - Before Merge
+    - name: Create phpcs.baseline.xml
       shell: bash
-      if: test -s ${{ github.workspace }}/phpcs_files.txt
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       run: |
         php vendor/bin/phpcs --standard=Magento2 \
         $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
         $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
         $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \
-        --report=\\DR\\CodeSnifferBaseline\\Reports\\Baseline --report-file=${{ github.workspace }}/phpcs.baseline.xml --file-list=${{ github.workspace }}/phpcs_files.txt || /bin/true
+        --report=\\DR\\CodeSnifferBaseline\\Reports\\Baseline --report-file=${{ github.workspace }}/phpcs.baseline.xml \
+        ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }} || /bin/true
+        
+        if [ -f "${{ github.workspace }}/phpcs.baseline.xml" ]; then
+          echo "phpcs.baseline.xml created successfully."
+        else
+          echo "phpcs.baseline.xml not created."
+          exit 1
+        fi
 
     - name: Checkout after Merge and execute phpcs
       shell: bash
-      if: test -s ${{ github.workspace }}/phpcs_files.txt
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       run: |
         if ${{ github.event_name == 'pull_request' }}; then
           git checkout ${{ github.event.pull_request.head.ref }}
         else
           git checkout ${{ github.event.after }}
         fi
+        
         php vendor/bin/phpcs --standard=Magento2 \
         $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
         $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
         $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \
-        --file-list=${{ github.workspace }}/phpcs_files.txt
+        ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }}

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -111,8 +111,8 @@ runs:
     - name: Register Coding Standard
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash
-      run: | 
-        vendor/bin/phpcs --config-set installed_paths \
+      run: |
+        ${{ github.workspace }}/vendor/bin/phpcs --config-set installed_paths \
         ${{ github.workspace }}/vendor/magento/magento-coding-standard,${{ github.workspace }}/vendor/phpcompatibility/php-compatibility
 
     - name: Create phpcs.baseline.xml in base

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -48,15 +48,25 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout Project
-      uses: actions/checkout@v3
+    - name: Checkout head
+      uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+        path: head
+
+    - name: Checkout base
+      uses: actions/checkout@v4
+      with:
+          ref: ${{github.event.pull_request.base.ref}}
+          repository: ${{github.event.pull_request.base.repo.full_name}}
+          path: base
 
     - name: Get all changed files
       uses: tj-actions/changed-files@v39
       id: changed-files-phpcs
       with:
+        path: head
         write_output_files: true
         output_dir: ${{ github.workspace }}
         separator: " "
@@ -107,18 +117,9 @@ runs:
       shell: bash
       run: vendor/bin/phpcs --config-set installed_paths ${{ github.workspace }}/vendor/magento/magento-coding-standard,${{ github.workspace }}/vendor/phpcompatibility/php-compatibility
 
-    - name: Checkout - Before Merge
-      shell: bash
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
-      run: |
-        if ${{ github.event_name == 'pull_request' }}; then
-          git checkout ${{ github.event.pull_request.base.ref }}
-        else
-          git checkout ${{ github.event.before }}
-        fi
-
     - name: Create phpcs.baseline.xml
       shell: bash
+      working-directory: base
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       run: |
         php vendor/bin/phpcs --standard=Magento2 \
@@ -135,16 +136,16 @@ runs:
           exit 1
         fi
 
+    - name: Copy baseline to head
+      shell: bash
+      run: |
+        cp ${{ github.workspace }}/base/phpcs.baseline.xml ${{ github.workspace }}/head/phpcs.baseline.xml
+
     - name: Checkout after Merge and execute phpcs
       shell: bash
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
-      run: |
-        if ${{ github.event_name == 'pull_request' }}; then
-          git checkout ${{ github.event.pull_request.head.ref }}
-        else
-          git checkout ${{ github.event.after }}
-        fi
-        
+      working-directory: head
+      run: |        
         php vendor/bin/phpcs --standard=Magento2 \
         $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
         $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -53,14 +53,6 @@ runs:
       with:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
-        path: head
-
-    - name: Checkout base
-      uses: actions/checkout@v4
-      with:
-          ref: ${{github.event.pull_request.base.ref}}
-          repository: ${{github.event.pull_request.base.repo.full_name}}
-          path: base
 
     - name: Get all changed files
       uses: tj-actions/changed-files@v39
@@ -77,6 +69,14 @@ runs:
             - '**/*.html'
             - '**/*.xml'
             - '**/*.js'
+
+    - name: Checkout base
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'false'
+      uses: actions/checkout@v4
+      with:
+          ref: ${{github.event.pull_request.base.ref}}
+          repository: ${{github.event.pull_request.base.repo.full_name}}
+          path: base
 
     - name: Inform if no files have changed
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'false'
@@ -132,18 +132,17 @@ runs:
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash
       run: |
-        cp ${{ github.workspace }}/base/phpcs.baseline.xml ${{ github.workspace }}/head/phpcs.baseline.xml
+        cp ${{ github.workspace }}/base/phpcs.baseline.xml ${{ github.workspace }}/phpcs.baseline.xml
 
     - name: Debug, cat baseline
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash
       run: |
-        cat ${{ github.workspace }}/head/phpcs.baseline.xml
+        cat ${{ github.workspace }}/phpcs.baseline.xml
 
     - name: Execute phpcs on head
       shell: bash
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
-      working-directory: head
       run: |        
         php ${{ github.workspace }}/vendor/bin/phpcs --standard=Magento2 \
         $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -58,7 +58,6 @@ runs:
       uses: tj-actions/changed-files@v39
       id: changed-files-phpcs
       with:
-        path: head
         files_yaml: |
           app:
             - '**/*.php'

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -48,11 +48,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Debug
-      shell: bash
-      run: |
-        echo "Comparing ${{github.event.pull_request.head.repo.full_name}}:${{github.event.pull_request.head.ref}} to ${{github.event.pull_request.base.repo.full_name}}:${{github.event.pull_request.base.ref}}"
-
     - name: Checkout head
       uses: actions/checkout@v4
       with:
@@ -80,14 +75,6 @@ runs:
       run: |
         echo "No files relevant to PHPCS have changed. Skipping PHPCS run."
         echo "List all the files that have changed: ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }}"
-
-    - name: Checkout base
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
-      uses: actions/checkout@v4
-      with:
-          ref: ${{github.event.pull_request.base.ref}}
-          repository: ${{github.event.pull_request.base.repo.full_name}}
-          path: base
 
     - name: Run step if test file(s) change
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
@@ -120,7 +107,15 @@ runs:
         ${{ github.workspace }}/vendor/bin/phpcs --config-set installed_paths \
         ${{ github.workspace }}/vendor/magento/magento-coding-standard,${{ github.workspace }}/vendor/phpcompatibility/php-compatibility
 
-    - name: Create phpcs.baseline.xml in base
+    - name: Checkout base to generate baseline
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
+      uses: actions/checkout@v4
+      with:
+        ref: ${{github.event.pull_request.base.ref}}
+        repository: ${{github.event.pull_request.base.repo.full_name}}
+        path: base
+
+    - name: Create phpcs.baseline.xml from base
       shell: bash
       working-directory: base
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
@@ -138,19 +133,15 @@ runs:
       run: |
         cp ${{ github.workspace }}/base/phpcs.baseline.xml ${{ github.workspace }}/phpcs.baseline.xml
 
+    # Since we ran phpcs in the base folder, the files in phpcs.baseline.xml contain the base folder in the path.
+    # We need to remove that so that the phpcs run in the head folder will find the files.
     - name: Remove base dir from phpcs baseline
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash
       run: |
         sed -i "s|/base/|/|" ${{ github.workspace }}/phpcs.baseline.xml
 
-    - name: Debug, cat baseline
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
-      shell: bash
-      run: |
-        cat ${{ github.workspace }}/phpcs.baseline.xml
-
-    - name: Execute phpcs on head
+    - name: Execute phpcs on head for changed files
       shell: bash
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       run: |        

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -134,12 +134,17 @@ runs:
       run: |
         cp ${{ github.workspace }}/base/phpcs.baseline.xml ${{ github.workspace }}/head/phpcs.baseline.xml
 
+    - name: Debug, cat baseline
+      shell: bash
+      run: |
+        cat ${{ github.workspace }}/head/phpcs.baseline.xml
+
     - name: Checkout after Merge and execute phpcs
       shell: bash
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       working-directory: head
       run: |        
-        php vendor/bin/phpcs --standard=Magento2 \
+        php ${{ github.workspace }}/vendor/bin/phpcs --standard=Magento2 \
         $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
         $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
         $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -128,13 +128,6 @@ runs:
         $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \
         --report=\\DR\\CodeSnifferBaseline\\Reports\\Baseline --report-file=${{ github.workspace }}/phpcs.baseline.xml \
         ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }} || /bin/true
-        
-        if [ -f "${{ github.workspace }}/phpcs.baseline.xml" ]; then
-          echo "phpcs.baseline.xml created successfully."
-        else
-          echo "phpcs.baseline.xml not created."
-          exit 1
-        fi
 
     - name: Copy baseline to head
       shell: bash

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -138,6 +138,12 @@ runs:
       run: |
         cp ${{ github.workspace }}/base/phpcs.baseline.xml ${{ github.workspace }}/phpcs.baseline.xml
 
+    - name: Remove base dir from phpcs baseline
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
+      shell: bash
+      run: |
+        sed -i "s|/base/|/|" ${{ github.workspace }}/phpcs.baseline.xml
+
     - name: Debug, cat baseline
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -83,7 +83,7 @@ runs:
         echo "One or more files relevant to PHPCS have changed."
         echo "List all the files that have changed: ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }}"
 
-    - name: Set PHP Version
+    - name: Setup PHP
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       uses: shivammathur/setup-php@v2
       with:
@@ -100,7 +100,7 @@ runs:
         composer config --no-plugins allow-plugins.digitalrevolution/php-codesniffer-baseline true
         composer require --dev "digitalrevolution/php-codesniffer-baseline: ${{ github.event.inputs.baseline_version || '*' }}"
 
-    - name: Register Coding Standard
+    - name: Register coding standards
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash
       run: |
@@ -134,7 +134,7 @@ runs:
         cp ${{ github.workspace }}/base/phpcs.baseline.xml ${{ github.workspace }}/phpcs.baseline.xml
 
     # Since we ran phpcs in the base folder, the files in phpcs.baseline.xml contain the base folder in the path.
-    # We need to remove that so that the phpcs run in the head folder will find the files.
+    # We need to remove /base/ so that the phpcs can locate the correct files.
     - name: Remove base dir from phpcs baseline
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -67,9 +67,6 @@ runs:
       id: changed-files-phpcs
       with:
         path: head
-        write_output_files: true
-        output_dir: ${{ github.workspace }}
-        separator: " "
         files_yaml: |
           app:
             - '**/*.php'
@@ -115,9 +112,11 @@ runs:
     - name: Register Coding Standard
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash
-      run: vendor/bin/phpcs --config-set installed_paths ${{ github.workspace }}/vendor/magento/magento-coding-standard,${{ github.workspace }}/vendor/phpcompatibility/php-compatibility
+      run: | 
+        vendor/bin/phpcs --config-set installed_paths \
+        ${{ github.workspace }}/vendor/magento/magento-coding-standard,${{ github.workspace }}/vendor/phpcompatibility/php-compatibility
 
-    - name: Create phpcs.baseline.xml
+    - name: Create phpcs.baseline.xml in base
       shell: bash
       working-directory: base
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
@@ -130,16 +129,18 @@ runs:
         ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }} || /bin/true
 
     - name: Copy baseline to head
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash
       run: |
         cp ${{ github.workspace }}/base/phpcs.baseline.xml ${{ github.workspace }}/head/phpcs.baseline.xml
 
     - name: Debug, cat baseline
+      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash
       run: |
         cat ${{ github.workspace }}/head/phpcs.baseline.xml
 
-    - name: Checkout after Merge and execute phpcs
+    - name: Execute phpcs on head
       shell: bash
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       working-directory: head

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -122,11 +122,11 @@ runs:
       working-directory: base
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       run: |
-        php vendor/bin/phpcs --standard=Magento2 \
+        php ${{ github.workspace }}/vendor/bin/phpcs --standard=Magento2 \
         $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
         $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
         $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \
-        --report=\\DR\\CodeSnifferBaseline\\Reports\\Baseline --report-file=${{ github.workspace }}/phpcs.baseline.xml \
+        --report=\\DR\\CodeSnifferBaseline\\Reports\\Baseline --report-file=phpcs.baseline.xml \
         ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }} || /bin/true
 
     - name: Copy baseline to head


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently the PHPCS baseline tests are failing when there are no files to check. See https://github.com/mage-os/mageos-magento2/actions/runs/5794755408/job/15940229468?pr=32.

## What is the new behavior?
- Stop before `composer install` step when phpcs has no files to check
- Only run phpcs for files in the app dir
- Simplify action, by utilising the build in function of [tj-actions/changed-files](https://github.com/tj-actions/changed-files) to check which files were modified.
- Trigger error when phpcs baseline was not created.
- Run phpcs on all filetypes that  are specified in the [Magento ruleset](https://github.com/magento/magento-coding-standard/blob/develop/Magento2/ruleset.xml#L5-L6)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Additional information
- [Example run](https://github.com/Tjitse-E/mageos-magento2/actions/runs/6110014181/job/16582167594) with adding an additional error in `app/code/Magento/Catalog/view/frontend/templates/product/breadcrumbs.phtml`, while there are existing errors in breadcrumbs.phtml (that are now in the baseline, so shoudn't be reported).
- [Example run](https://github.com/Tjitse-E/mageos-magento2/actions/runs/6110345217/job/16583150086) when there are no relevant phpcs files changed.

## Related PR
https://github.com/mage-os/mageos-magento2/pull/32