### PR TITLE
feat: run setup:di:compile on push

### DIFF
--- a/setup-di-compile/README.md
+++ b/setup-di-compile/README.md
@@ -13,9 +13,13 @@ name: Magento setup:di:compile check
 on:
   push:
     branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
-  coding-standard:
+  setup-di-compile:
     runs-on: ubuntu-latest
     steps:
     - uses: mage-os/github-actions/setup-di-compile@main

--- a/setup-di-compile/README.md
+++ b/setup-di-compile/README.md
@@ -1,0 +1,25 @@
+# Magento 2 setup:di:compile action
+A Github Action that runs `php bin/magento setup:di:compile` and checks for compilation errors.
+
+## Inputs
+
+See the [action.yml](./action.yml)
+
+## Usage
+
+```yml
+name: Magento setup:di:compile check
+
+on:
+  push:
+    branches:
+
+jobs:
+  coding-standard:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: mage-os/github-actions/setup-di-compile@main
+      with:
+        php_version: "8.2"
+        composer_version: "2"
+```

--- a/setup-di-compile/README.md
+++ b/setup-di-compile/README.md
@@ -24,6 +24,6 @@ jobs:
     steps:
     - uses: mage-os/github-actions/setup-di-compile@main
       with:
-        php_version: "8.2"
+        php_version: "8.3"
         composer_version: "2"
 ```

--- a/setup-di-compile/action.yml
+++ b/setup-di-compile/action.yml
@@ -18,8 +18,6 @@ runs:
   steps:
     - name: Checkout Project
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: Get changed files that could break compilation
       uses: tj-actions/changed-files@v39

--- a/setup-di-compile/action.yml
+++ b/setup-di-compile/action.yml
@@ -6,7 +6,7 @@ inputs:
   php_version:
     required: true
     default: "8.1"
-    description: "PHP version used to do the coding standard check."
+    description: "PHP version used to run setup:di:compile."
 
   composer_version:
     required: true
@@ -39,6 +39,10 @@ runs:
         php-version: ${{ inputs.php_version }}
         tools: composer:v${{ inputs.composer_version }}
         coverage: none
+
+    - uses: mage-os/github-actions/cache-magento@main
+      with:
+        mode: 'store'
 
     - name: Install composer dependencies
       if: steps.changed-files.outputs.magento_any_changed == 'true'

--- a/setup-di-compile/action.yml
+++ b/setup-di-compile/action.yml
@@ -1,0 +1,56 @@
+name: "Magento compilation (setup:di:compile)"
+author: "MageOS"
+description: "A Github Action that runs bin/magento setup:di:compile."
+
+inputs:
+  php_version:
+    required: true
+    default: "8.1"
+    description: "PHP version used to do the coding standard check."
+
+  composer_version:
+    required: true
+    default: "2"
+    description: "The version of composer to use."
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout Project
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Get changed files that could break compilation
+      uses: tj-actions/changed-files@v39
+      id: changed-files
+      with:
+        files_yaml: |
+          magento:
+            - 'composer.lock'
+            - 'composer.json'
+            - '**/*.php'
+            - '**/*.xml'
+
+    - name: Set PHP Version
+      if: steps.changed-files.outputs.magento_any_changed == 'true'
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php_version }}
+        tools: composer:v${{ inputs.composer_version }}
+        coverage: none
+
+    - name: Install composer dependencies
+      if: steps.changed-files.outputs.magento_any_changed == 'true'
+      shell: bash
+      run: composer install
+
+    - name: Enable all modules
+      if: steps.changed-files.outputs.magento_any_changed == 'true'
+      shell: bash
+      run: php bin/magento module:enable --all
+
+    - name: Compile
+      if: steps.changed-files.outputs.magento_any_changed == 'true'
+      shell: bash
+      run: php bin/magento setup:di:compile

--- a/setup-di-compile/action.yml
+++ b/setup-di-compile/action.yml
@@ -5,7 +5,7 @@ description: "A Github Action that runs bin/magento setup:di:compile."
 inputs:
   php_version:
     required: true
-    default: "8.1"
+    default: "8.3"
     description: "PHP version used to run setup:di:compile."
 
   composer_version:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the new behavior?
Run `php bin/magento setup:di:compile` on pushes, only when files are pushed that can actually break compilation in Mage-OS (PHP, XML or composer changes).

[Example fail](https://github.com/Tjitse-E/mageos-magento2/actions/runs/6111150364/job/16585736317).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No