### PR TITLE
chore: make a demo of actions

### DIFF
--- a/.github/workflows/_internal_test.yml
+++ b/.github/workflows/_internal_test.yml
@@ -1,0 +1,27 @@
+name: Test Actions
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+    preTest: 
+        runs-on: ubuntu-latest
+        outputs:
+          services: ${{ steps.services.outputs.serviceJson }}
+        steps:
+          - uses: actions/checkout@v3
+          - run: echo "serviceJson=$(cat .github/workflows/demo.json | jq -c)" >> "$GITHUB_OUTPUT"
+            id: services
+            shell: bash
+          
+            
+    test: 
+        runs-on: ubuntu-latest
+        needs: [preTest]
+        services: ${{ fromJson(needs.preTest.outputs.services ) }}
+        steps:
+        - run: echo "Hello"
+          shell: bash
+        

--- a/.github/workflows/demo.json
+++ b/.github/workflows/demo.json
@@ -1,0 +1,38 @@
+{
+    "elasticsearch": {
+        "image": "elasticsearch:8.5.3",
+        "env": {
+            "discovery.type": "single-node",
+            "xpack.security.enabled": false,
+            "xpack.security.http.ssl.enabled": false,
+            "xpack.security.transport.ssl.enabled": false
+        },
+        "options": "--health-cmd \"curl http://localhost:9200/_cluster/health\" --health-interval 10s --health-timeout 5s --health-retries 10",
+        "ports": [
+            "9200:9200"
+        ]
+    },
+    "mysql": {
+        "image": "mysql:8.0",
+        "env": {
+            "MYSQL_DATABASE": "magento_integration_tests",
+            "MYSQL_USER": "user",
+            "MYSQL_PASSWORD": "password",
+            "MYSQL_ROOT_PASSWORD": "rootpassword"
+        },
+        "ports": [
+            "3306:3306"
+        ],
+        "options": "--health-cmd=\"mysqladmin ping\" --health-interval=10s --health-timeout=5s --health-retries=3"
+    },
+    "rabbitmq": {
+        "image": "rabbitmq:3.9-management",
+        "env": {
+            "RABBITMQ_DEFAULT_USER": "guest",
+            "RABBITMQ_DEFAULT_PASS": "guest"
+        },
+        "ports": [
+            "5672:5672"
+        ]
+    }
+}


### PR DESCRIPTION
This is a demo of an idea I had while reviewing code from @gowrizrh @danslo and @vpodorozh as well as @jissereitsma and @sprankhub  in the context of #97 and #14 as well https://github.com/mage-os/infrastructure/blob/main/.github/workflows/unit-tests.yml

I really really really hate the duplication we all have across various actions. We really don't need to do that, as I've just discovered. 

We can leverage the same ideas I did with `supported-versions` to encapsulate all that `services` logic.

This doesn't use `warden` but perhaps we could work with the @navarr to come up with something similar?