### PR TITLE
feat(semver-compare): add new Github action

### DIFF
--- a/.github/workflows/_internal-semver-compare.yaml
+++ b/.github/workflows/_internal-semver-compare.yaml
@@ -1,0 +1,69 @@
+name: Test semvar-compare action
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - ".github/workflows/_internal-semver-compare.yaml"
+    - "semver-compare/**"
+    - "!(**/*.md)"
+  pull_request:
+    branches:
+    - main
+    paths:
+    - ".github/workflows/_internal-semver-compare.yaml"
+    - "semver-compare/**"
+    - "!(**/*.md)"
+
+jobs:
+  semver-compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./semver-compare
+        id: version-compare-1
+        with:
+          version: 2.2.3
+          compare_against: 2.3
+
+      - uses: ./semver-compare
+        id: version-compare-2
+        with:
+          version: 2
+          compare_against: 2.0.1
+
+      - uses: ./semver-compare
+        id: version-compare-3
+        with:
+          version: 2.2.1
+          compare_against: 2.2
+
+
+      - uses: ./semver-compare
+        id: version-compare-4
+        with:
+          version: 2.2.0
+          compare_against: 2.2.0
+
+      - name: Fail if 2.3 is not higher than 2.2.3
+        if: steps.version-compare-1.outputs.result != -1
+        shell: bash
+        run: echo "FAIL because 2.3 must be higher than 2.2.3 Compare 2.2.3 to 2.3 renders ${{ steps.version-compare-1.outputs.result }}" && exit 1
+
+
+      - name: Fail if 2.0.1 is not higher than 2
+        if: steps.version-compare-2.outputs.result != -1
+        shell: bash
+        run: echo "FAIL because 2.0.1 must be higher than 2 Compare 2 to 2.0.1 renders ${{ steps.version-compare-2.outputs.result }}" && exit 1
+
+      - name: Fail if 2.2.1 is not higher than 2.2
+        if: steps.version-compare-3.outputs.result != 1
+        shell: bash
+        run: echo "FAIL because 2.2.1 must be higher than 2.2 Compare 2.2.1 to 2.2 renders ${{ steps.version-compare-3.outputs.result }}" && exit 1
+
+      - name: Fail if 2.2.0 is not equals to 2.2.0
+        if: steps.version-compare-4.outputs.result != 0
+        shell: bash
+        run: echo "FAIL because 2.2.0 must be equal to 2.2.0 Compare 2.2.0 to 2.2.0 renders ${{ steps.version-compare-4.outputs.result }}" && exit 1

--- a/README.md
+++ b/README.md
@@ -31,4 +31,5 @@ Opinionated Github Actions and Workflows to make building, testing, and maintain
 | [Setup Magento](./setup-magento/README.md)             | A Github Action that sets up Magento before `composer install` for an extension or store. |
 | [Get Magento Version](./get-magento-version/README.md) | A Github Action that computes the installed Magento version.                              |
 | [Installation Test](./installation-test/README.md)     | A Github Action that tests the installability of a Magento Package                        |
+| [Semver Compare](./semver-compare/README.md)           | A Github Action that semantically compares two versions                                   |
 | [Supported Version](./supported-version/README.md)     | A Github Action that computes the currently supported Github Actions Matrix for Magento 2 |

--- a/semver-compare/README.md
+++ b/semver-compare/README.md
@@ -1,0 +1,41 @@
+# "Semver Compare" Action
+
+A Github Action that semantically compares two versions, like 2.1.1 and 2.3.0 giving information about whether or the version is "higher" or "lower" than another version. The action exposes an output called `result` which will match the return type of the PHP [version_compare](https://www.php.net/manual/en/function.version-compare.php) function.
+
+Currently, this action compares `version` against `compare_against` and returns:
+
+- `-1` - if `version` is lower than `compare_against`
+- `0` - if `version` is equal to `compare_against`
+- `1` - if `version` is greater than `compare_against`
+
+## Inputs
+
+See the [action.yml](./action.yml)
+
+## Usage
+
+```yml
+name: Semver Compare
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    name: A job to semantically compare two versions
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mage-os/github-actions/semver-compare@main
+        with:
+          version: 2.1.0
+          compare_against: 2.2.3
+          id: semver-compare
+      - run: echo version ${{ steps.semver-compare.outputs.result }}
+        shell: bash
+```

--- a/semver-compare/action.yml
+++ b/semver-compare/action.yml
@@ -1,0 +1,29 @@
+name: "Semver Compare"
+author: "Graycore"
+description: "A Github Action that compares two versions, semantically"
+
+inputs:
+  version:
+    required: true
+    description: "Original version"
+
+  compare_against:
+    required: true
+    description: "The version to compare against"
+
+outputs:
+  result: # id of output
+    description: "The result of comparison. By default, this returns -1 if the first version is lower than the second, 0 if they are equal, and 1 if the second is lower."
+    value: ${{ steps.semver-compare.outputs.result }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Semantically compare two versions
+      run: php -r "echo 'result=' . version_compare('${{ inputs.version }}', '${{ inputs.compare_against }}');" >> $GITHUB_OUTPUT
+      shell: bash
+      id: semver-compare
+
+branding:
+  icon: "code"
+  color: "green"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, we don't have a way to compare semver versions making handling BC issues a challenge.

Touches #132 


## What is the new behavior?
This adds a new Github Action that semantically compares two versions, like 2.1.1 and 2.3.0 giving information about whether or the version is "higher" or "lower" than another version. The action exposes an output called `result` which will match the return type of the PHP [version_compare](https://www.php.net/manual/en/function.version-compare.php) function.

Currently, this action compares `version` against `compare_against` and returns:

- `-1` - if `version` is lower than `compare_against`
- `0` - if `version` is equal to `compare_against`
- `1` - if `version` is greater than `compare_against`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
