### PR TITLE
feat(coding-standard): add `ignore_warnings` flag

### DIFF
--- a/.github/workflows/_internal-coding-standard.yaml
+++ b/.github/workflows/_internal-coding-standard.yaml
@@ -31,7 +31,23 @@ on:
         required: true
 
 jobs:
+  compute_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.supported-version.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./supported-version
+        with:
+          kind: all
+        id: supported-version
+      - run: echo ${{ steps.supported-version.outputs.matrix }}
+
   coding-standard:
+    needs: compute_matrix
+    strategy:
+      matrix: ${{ fromJSON(needs.compute_matrix.outputs.matrix) }}
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -39,3 +55,5 @@ jobs:
         with:
           version: ${{ github.event.inputs.version || '*' }}
           path: ${{ github.event.inputs.path || '_test/demo-package' }}
+          composer_version: ${{ matrix.composer }}
+          php_version: ${{ matrix.php }}

--- a/coding-standard/action.yml
+++ b/coding-standard/action.yml
@@ -37,6 +37,11 @@ inputs:
     default: ""
     description: "The minimum severity required to display an error"
 
+  ignore_warnings:
+    description: 'Whether or not the action should fail on warnings, defaults to false (fails on warnings)'
+    default: 'false'
+    required: false
+
 runs:
   using: composite
   steps:
@@ -57,6 +62,23 @@ runs:
         tools: composer:v${{ inputs.composer_version }}
         coverage: none
 
+    - name: Get Composer Version
+      uses: mage-os/github-actions/get-composer-version@main
+      id: get-composer-version
+
+    - name: Check if allow-plugins option is available for this version of composer
+      uses: mage-os/github-actions/semver-compare@main
+      with:
+        version: 2.2
+        compare_against: ${{ steps.get-composer-version.outputs.version }}
+      id: is-allow-plugins-available
+
+    - name: Enable dealerdirect/phpcodesniffer-composer-installer plugin
+      shell: bash
+      working-directory: standard
+      run: composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer  true --global
+      if: steps.is-allow-plugins-available.outputs.result < 1
+
     - name: Install Coding Standard
       shell: bash
       working-directory: standard
@@ -66,6 +88,12 @@ runs:
       shell: bash
       working-directory: standard
       run: vendor/bin/phpcs --config-set installed_paths ${{ github.workspace }}/standard/vendor/magento/magento-coding-standard,${{ github.workspace }}/standard/vendor/phpcompatibility/php-compatibility
+
+    - name: Set ignore warnings flag
+      shell: bash
+      working-directory: standard
+      run: vendor/bin/phpcs --config-set ignore_warnings_on_exit 1
+      if: inputs.ignore_warnings == 'true'
 
     - name: Get Changed Files
       shell: bash


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
By default, `phpcs` exits with a non-zero exit code when it finds warnings. Additionally, we fixed an issue with older versions of composer.

Fixes: #130 
Supersedes: #132 

## What is the new behavior?
- We expose a new input called `ignore_warnings` that causes them to be reported, but still exit `0`
- We both test against and fix an issue with older versions of composers that don't have plugins. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
