### PR TITLE
feat: Allow custom phpcs coding standard

### DIFF
--- a/coding-standard-baseline/README.md
+++ b/coding-standard-baseline/README.md
@@ -32,4 +32,6 @@ jobs:
         warning_severity: "8"
         error_severity: "8"
         baseline_version: "*"
+        coding_standard: "Magento2"
+        custom_coding_standard_repo: "your/custom-repo"
 ```

--- a/coding-standard-baseline/README.md
+++ b/coding-standard-baseline/README.md
@@ -32,6 +32,4 @@ jobs:
         warning_severity: "8"
         error_severity: "8"
         baseline_version: "*"
-        coding_standard: "Magento2"
-        custom_coding_standard_repo: "your/custom-repo"
 ```

--- a/coding-standard/README.md
+++ b/coding-standard/README.md
@@ -30,4 +30,6 @@ jobs:
         severity: 8 # Optional, will use phpcs default of 5 if not specified.
         warning_severity: 4 # Optional, will use severity value if not specified.
         error_severity: 7 # Optional, will use severity value if not specified.
+        coding_standard: "Magento2"
+        custom_coding_standard_repo: "your/custom-repo"
 ```

--- a/coding-standard/action.yml
+++ b/coding-standard/action.yml
@@ -21,17 +21,17 @@ inputs:
   version:
     required: false
     description: "The version of the coding standard to use. If not provided, will use the latest version."
-    
+
   severity:
     required: false
     default: ""
     description: "The minimum severity required to display an error or warning (default: 5)"
-  
+
   warning_severity:
     required: false
     default: ""
     description: "The minimum severity required to display a warning"
-  
+
   error_severity:
     required: false
     default: ""
@@ -40,6 +40,16 @@ inputs:
   ignore_warnings:
     description: 'Whether or not the action should fail on warnings, defaults to false (fails on warnings)'
     default: 'false'
+    required: false
+
+  coding_standard:
+    description: 'The coding standard to use, defaults to Magento2'
+    default: 'Magento2'
+    required: false
+
+  custom_coding_standard_repo:
+    description: 'The repository to use for the coding standard, used if you want to use a custom coding standard'
+    default: ''
     required: false
 
 runs:
@@ -79,10 +89,15 @@ runs:
       run: composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer  true --global
       if: steps.is-allow-plugins-available.outputs.result < 1
 
-    - name: Install Coding Standard
+    - name: Install Magento2 Coding Standard
       shell: bash
       working-directory: standard
       run: composer require "magento/magento-coding-standard:${{ inputs.version || '*' }}"
+
+    - name: Install Custom Coding Standard
+      if: ${{ inputs.coding_standard_repo }}
+      shell: bash
+      run: composer require "${{ inputs.coding_standard_repo }}"
 
     - name: Register Coding Standard
       shell: bash
@@ -105,7 +120,8 @@ runs:
     - name: Coding Standard Check
       shell: bash
       run: |
-        ../standard/vendor/bin/phpcs --standard=Magento2 \
+        ../standard/vendor/bin/phpcs \
+        --standard="${{ inputs.coding_standard }}"
         $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
         $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
         $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \

--- a/coding-standard/action.yml
+++ b/coding-standard/action.yml
@@ -89,6 +89,11 @@ runs:
       run: composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer  true --global
       if: steps.is-allow-plugins-available.outputs.result < 1
 
+    - name: Install composer require dealerdirect/phpcodesniffer-composer-installer
+      shell: bash
+      working-directory: standard
+      run: composer require dealerdirect/phpcodesniffer-composer-installer
+
     - name: Install Magento2 Coding Standard
       shell: bash
       working-directory: standard
@@ -98,11 +103,6 @@ runs:
       if: ${{ inputs.custom_coding_standard_repo }}
       shell: bash
       run: composer require "${{ inputs.custom_coding_standard_repo }}"
-
-    - name: Register Coding Standard
-      shell: bash
-      working-directory: standard
-      run: vendor/bin/phpcs --config-set installed_paths ${{ github.workspace }}/standard/vendor/magento/magento-coding-standard,${{ github.workspace }}/standard/vendor/phpcompatibility/php-compatibility
 
     - name: Set ignore warnings flag
       shell: bash

--- a/coding-standard/action.yml
+++ b/coding-standard/action.yml
@@ -118,6 +118,10 @@ runs:
       run: echo "files=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | xargs)" >> $GITHUB_OUTPUT
       if: github.event_name == 'pull_request'
 
+    - name: Validate input
+      shell: bash
+      run: ls -la ${{ github.event_name == 'pull_request' && steps.changed-files.outputs.files || inputs.path }}
+
     - name: Coding Standard Check
       shell: bash
       run: |

--- a/coding-standard/action.yml
+++ b/coding-standard/action.yml
@@ -118,15 +118,11 @@ runs:
       run: echo "files=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | xargs)" >> $GITHUB_OUTPUT
       if: github.event_name == 'pull_request'
 
-    - name: Validate input
-      shell: bash
-      run: ls -la ${{ github.event_name == 'pull_request' && steps.changed-files.outputs.files || inputs.path }}
-
     - name: Coding Standard Check
       shell: bash
       run: |
         ../standard/vendor/bin/phpcs \
-        --standard="${{ inputs.coding_standard }}"
+        --standard="${{ inputs.coding_standard }}" \
         $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
         $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
         $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \

--- a/coding-standard/action.yml
+++ b/coding-standard/action.yml
@@ -95,9 +95,9 @@ runs:
       run: composer require "magento/magento-coding-standard:${{ inputs.version || '*' }}"
 
     - name: Install Custom Coding Standard
-      if: ${{ inputs.coding_standard_repo }}
+      if: ${{ inputs.custom_coding_standard_repo }}
       shell: bash
-      run: composer require "${{ inputs.coding_standard_repo }}"
+      run: composer require "${{ inputs.custom_coding_standard_repo }}"
 
     - name: Register Coding Standard
       shell: bash

--- a/coding-standard/action.yml
+++ b/coding-standard/action.yml
@@ -102,6 +102,7 @@ runs:
     - name: Install Custom Coding Standard
       if: ${{ inputs.custom_coding_standard_repo }}
       shell: bash
+      working-directory: standard
       run: composer require "${{ inputs.custom_coding_standard_repo }}"
 
     - name: Set ignore warnings flag


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, when `mage-os/github-actions/coding-standard` is used the Magento 2 coding standard is always used.  

## What is the new behavior?
If we want to make this the default PHPCS coding standard workflow we should add an option to specify a custom coding standard. This is usefull for vendors who want to modify/add sniffs to the official Magento 2 coding standards.

For example, we have [excluded some rules](https://github.com/Vendic/magento-coding-standard/blob/main/VendicMagento2/ruleset.xml)

You can see the new options in action [here](https://github.com/Vendic/hyva-checkout-create-account/actions/runs/6272309837/job/17033602847)

In addition to this, i've also added `dealerdirect/phpcodesniffer-composer-installer`, so all of the available phpcs standards in the project are automatically registered. The "Register Coding Standard" step became redundant and was removed.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
