### PR TITLE
fix: pass correct repo url for nightly

### DIFF
--- a/supported-version/src/matrix/get-matrix-for-kind.spec.ts
+++ b/supported-version/src/matrix/get-matrix-for-kind.spec.ts
@@ -36,6 +36,7 @@ describe('getMatrixForKind for mage-os', () => {
         const result = getMatrixForKind("nightly", project);
         expect(result.magento).toBeDefined();
         expect(result.include).toBeDefined();
+        expect(result.magento[0]).toBe('mage-os/project-community-edition:@alpha');
     });
 
     it('returns a matrix for the next release when using `nightly`', () => {

--- a/supported-version/src/matrix/get-matrix-for-kind.ts
+++ b/supported-version/src/matrix/get-matrix-for-kind.ts
@@ -14,7 +14,7 @@ export const getMatrixForKind = (kind: string, project: string, versions = "") =
         case 'currently-supported':
           return getMatrixForVersions(project, getCurrentlySupportedVersions(project, new Date()));
         case 'nightly':
-          return amendMatrixForNext(getMatrixForVersions(project, nightlyJson[project]), 'https://upstream-mirror.mage-os.org', getDayBefore());
+          return amendMatrixForNext(getMatrixForVersions(project, nightlyJson[project]), 'https://upstream-nightly.mage-os.org', getDayBefore());
         case 'all':
           return getMatrixForVersions(project, Object.keys(getIndividualVersionsForProject(project)));
         case 'custom':


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `amendMatrixForNext` function uses the repository argument to determine the version constraint for the returned matrix for kind nightly.  

Previously, the upstream-mirror repo url was passed as an argument, but the nightly builds use a different repo url.
This resulted in failed builds, because the version string 'next' could not be parsed by composer.

Example:
https://github.com/mage-os/generate-mirror-repo-js/actions/runs/6370219504/job/17291152703

## What is the new behavior?

With this change, the nightly kind will always return the `@alpha` version constraint, that is, stability constraint. There currently is no way to distinguish between different nightly repos, but since both work the same way, this is fine (for now).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

