### PR TITLE
fix: PHPcs baseline composer conflicts

### DIFF
--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -91,21 +91,21 @@ runs:
         tools: composer:v${{ inputs.composer_version }}
         coverage: none
 
-    - name: Install Coding Standard && Codesniffer baseline
+    - name: Create composer project
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       shell: bash
       run: |
-        git config --global advice.detachedHead false
-        composer require "magento/magento-coding-standard: ${{ github.event.inputs.version || '*' }}" -W
-        composer config --no-plugins allow-plugins.digitalrevolution/php-codesniffer-baseline true
-        composer require --dev "digitalrevolution/php-codesniffer-baseline: ${{ github.event.inputs.baseline_version || '*' }}"
+        composer create-project --no-plugins --no-dev \
+        magento/magento-coding-standard \
+        magento-coding-standard "${{ github.event.inputs.version || '*' }}"
 
     - name: Register coding standards
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
+      working-directory: magento-coding-standard
       shell: bash
       run: |
-        ${{ github.workspace }}/vendor/bin/phpcs --config-set installed_paths \
-        ${{ github.workspace }}/vendor/magento/magento-coding-standard,${{ github.workspace }}/vendor/phpcompatibility/php-compatibility
+        composer config --no-plugins allow-plugins.digitalrevolution/php-codesniffer-baseline true
+        composer require --dev "digitalrevolution/php-codesniffer-baseline: ${{ github.event.inputs.baseline_version || '*' }}"
 
     - name: Checkout base to generate baseline
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
@@ -120,7 +120,7 @@ runs:
       working-directory: base
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       run: |
-        php ${{ github.workspace }}/vendor/bin/phpcs --standard=Magento2 \
+        php ${{ github.workspace }}/magento-coding-standard/vendor/bin/phpcs --standard=Magento2 \
         $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
         $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
         $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \
@@ -145,7 +145,7 @@ runs:
       shell: bash
       if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
       run: |        
-        php ${{ github.workspace }}/vendor/bin/phpcs --standard=Magento2 \
+        php ${{ github.workspace }}/magento-coding-standard/vendor/bin/phpcs --standard=Magento2 \
         $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
         $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
         $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, PHPcs is installed in the project directory which could lead to composer conflicts. This happens in run https://github.com/mage-os/mageos-magento2/actions/runs/6395972215/job/17360788696?pr=21.

## What is the new behavior?
With this change, we'll install the coding standards seperate from the project in a new directory `magento-coding-standard` and we'll run phpcs from that directory.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
See test run https://github.com/Tjitse-E/mageos-magento2/actions/runs/6428118581/job/17455153997