### PR TITLE
Fix changed files action for phpcs baseline 

### DIFF
--- a/coding-standard-baseline/README.md
+++ b/coding-standard-baseline/README.md
@@ -1,15 +1,23 @@
 # Magento 2 Coding Standard Action
 
-A Github Action that runs the Magento Coding Standard.
+This Github Action automates the enforcement of Magento Coding Standards. It ensures code consistency and quality by checking code against Magento's specific coding guidelines.
 
 ## Inputs
 
-See the [action.yml](./action.yml)
+For detailed descriptions of each input, refer to [action.yml](./action.yml).
 
-## Usage
+## Why a Baseline?
+
+Running PHP CodeSniffer (PHPCS) with a baseline is crucial for managing legacy code. It allows you to set a "starting point" for code quality, ignoring existing issues while ensuring no new issues are introduced. This approach is especially useful for large codebases where addressing all existing issues at once is not feasible. The baseline serves as a record of known issues, enabling teams to focus on maintaining and gradually improving code quality in new or modified code.
+
+## Usage Example
+
+The following example demonstrates how to set up the action in your workflow:
+
+Check how this action is used in mage-os [here](https://github.com/mage-os/mageos-magento2/blob/2.4-develop/.github/workflows/coding-standard-baseline.yml).
 
 ```yml
-name: Coding Standard baseline
+name: Coding Standard Baseline
 
 on:
   push:
@@ -25,6 +33,8 @@ jobs:
     steps:
     - uses: mage-os/github-actions/coding-standard-baseline@main
       with:
+        head_repo: "mage-os/mageos-magento2"
+        head_ref: "main"
         php_version: "8.2"
         composer_version: "2"
         version: "*"

--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -45,70 +45,67 @@ inputs:
     default: "*"
     description: "The version of phpcs baseline to use (default: latest)."
 
+  head_repo:
+    type: string
+    required: true
+    description: "The repository full name of the head branch. E.g.: mage-os/mageos-magento2"
+
+  head_ref:
+    type: string
+    required: true
+    description: "The branch name of the head branch. E.g.: main"
+
 runs:
   using: composite
   steps:
     - name: Checkout head
       uses: actions/checkout@v4
       with:
-        ref: ${{github.event.pull_request.head.ref}}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
+        ref: ${{ inputs.head_ref }}
+        repository: ${{ inputs.head_repo }}
 
-    - name: Get all changed files
-      uses: tj-actions/changed-files@v39
-      id: changed-files-phpcs
+    - uses: dorny/paths-filter@v2
+      name: Filter changed files
+      id: filter
       with:
-        files_yaml: |
-          app:
-            - '**/*.php'
-            - '**/*.phtml'
-            - '**/*.graphqls'
-            - '**/*.less'
-            - '**/*.css'
-            - '**/*.html'
-            - '**/*.xml'
-            - '**/*.js'
+        list-files: shell
+        filters: |
+          phpcs:
+            - added|modified: '**/**.{php,phtml,graphqls,less,css,html,xml,js}'
 
-    - name: Inform if no files have changed
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'false'
-      shell: bash
-      run: |
-        echo "No files relevant to PHPCS have changed. Skipping PHPCS run."
-        echo "List all the files that have changed: ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }}"
-
-    - name: Inform if relevant files have changed
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
+    - name: Check changed files for PHPcs
+      if: steps.filter.outputs.phpcs == 'true'
       shell: bash
       run: |
         echo "One or more files relevant to PHPCS have changed."
-        echo "List all the files that have changed: ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }}"
+        echo "List all the files that have changed: ${{ steps.filter.outputs.phpcs_files }}"
 
     - name: Setup PHP
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
+      if: steps.filter.outputs.phpcs == 'true'
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ inputs.php_version }}
         tools: composer:v${{ inputs.composer_version }}
         coverage: none
 
-    - name: Create composer project
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
+    - name: Install coding standards
+      if: steps.filter.outputs.phpcs == 'true'
       shell: bash
       run: |
         composer create-project --no-plugins --no-dev \
         magento/magento-coding-standard \
         magento-coding-standard "${{ github.event.inputs.version || '*' }}"
 
-    - name: Register coding standards
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
+    - name: Install phpcs baseline
+      if: steps.filter.outputs.phpcs == 'true'
       working-directory: magento-coding-standard
       shell: bash
       run: |
         composer config --no-plugins allow-plugins.digitalrevolution/php-codesniffer-baseline true
         composer require --dev "digitalrevolution/php-codesniffer-baseline: ${{ github.event.inputs.baseline_version || '*' }}"
 
-    - name: Checkout base to generate baseline
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
+    - name: Checkout base
+      if: steps.filter.outputs.phpcs == 'true'
       uses: actions/checkout@v4
       with:
         ref: ${{github.event.pull_request.base.ref}}
@@ -118,17 +115,17 @@ runs:
     - name: Create phpcs.baseline.xml from base
       shell: bash
       working-directory: base
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
+      if: steps.filter.outputs.phpcs == 'true'
       run: |
         php ${{ github.workspace }}/magento-coding-standard/vendor/bin/phpcs --standard=Magento2 \
         $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
         $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
         $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \
         --report=\\DR\\CodeSnifferBaseline\\Reports\\Baseline --report-file=phpcs.baseline.xml \
-        ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }} || /bin/true
+        ${{ steps.filter.outputs.phpcs_files }} || /bin/true
 
     - name: Copy baseline to head
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
+      if: steps.filter.outputs.phpcs == 'true'
       shell: bash
       run: |
         cp ${{ github.workspace }}/base/phpcs.baseline.xml ${{ github.workspace }}/magento-coding-standard/phpcs.baseline.xml
@@ -136,17 +133,17 @@ runs:
     # Since we ran phpcs in the base folder, the files in phpcs.baseline.xml contain the base folder in the path.
     # We need to remove /base/ so that the phpcs can locate the correct files.
     - name: Remove base dir from phpcs baseline
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
+      if: steps.filter.outputs.phpcs == 'true'
       shell: bash
       run: |
         sed -i "s|/base/|/|" ${{ github.workspace }}/magento-coding-standard/phpcs.baseline.xml
 
     - name: Execute phpcs on head for changed files
       shell: bash
-      if: steps.changed-files-phpcs.outputs.app_any_changed == 'true'
-      run: |        
+      if: steps.filter.outputs.phpcs == 'true'
+      run: |
         php ${{ github.workspace }}/magento-coding-standard/vendor/bin/phpcs --standard=Magento2 \
         $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
         $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
         $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \
-        ${{ steps.changed-files-phpcs.outputs.app_all_changed_files }}
+        ${{ steps.filter.outputs.phpcs_files }}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently we use `tj-actions/changed-files` to extract the files changed in a PR. This caused issues in [the integration testing PR](https://github.com/mage-os/mageos-magento2/pull/57): the reported changed files were invalid and not changed by the PR.

I've fixed this by using `dorny/paths-filter` to extract the files that need checking with PHCPcs. It's a Github action we have been using for almost a year internally at Vendic. Using `dorny/paths-filter` we can only filter added or modified files that match our glob.

## What is the new behavior?
In addition to that I also moved the repo and ref to the action input. This allows for easier testing specific PR's if more bugs occur in the future

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

See https://github.com/mage-os/mageos-magento2/pull/59

## Other information
See an example that shows the correct behaviour [here](https://github.com/Tjitse-E/mageos-magento2/actions/runs/6890983582/job/18745450575).
This run:
 - demonstrates that the baseline works, since the scanned file (`app/code/Magento/AdminAnalytics/Model/ResourceModel/Viewer/Logger.php`) contains an existing phpcs issue ` 24 | WARNING | Visibility must be declared on all constants if your project supports PHP 7.1 or later`.
- demonstrates that the action extracts the correct files to scan for phpcs

