### PR TITLE
Allow ignoring integration tests

### DIFF
--- a/.github/workflows/full-integration-tests.yaml
+++ b/.github/workflows/full-integration-tests.yaml
@@ -231,6 +231,11 @@ jobs:
           echo "Debug: $NEW_TESTSUITE_ENTRY"
           awk -v new_testsuite="$NEW_TESTSUITE_ENTRY" '/<\/testsuites>/ { print new_testsuite; found=1 } {print} END { if (!found) print new_testsuite }' "$FILE" > tmpfile && mv tmpfile "$FILE"
           echo "\nMage-OS suite has been added to $FILE \n"
+          
+          ## TODO: do not execute in case input params are provided for running full suite
+          sed -i '/<testsuites>/i\<groups>\<exclude>\<group>integrationIgnore<\/group><\/exclude><\/groups>' "$FILE"
+          echo "\nIgnore group `integrationIgnore` has been added to $FILE \n"
+          
           cat $FILE;
 
       - name: Run Integration Tests for Modules

--- a/.github/workflows/full-integration-tests.yaml
+++ b/.github/workflows/full-integration-tests.yaml
@@ -232,7 +232,7 @@ jobs:
           awk -v new_testsuite="$NEW_TESTSUITE_ENTRY" '/<\/testsuites>/ { print new_testsuite; found=1 } {print} END { if (!found) print new_testsuite }' "$FILE" > tmpfile && mv tmpfile "$FILE"
           echo "\nMage-OS suite has been added to $FILE \n"
           
-          ## TODO: do not execute in case input params are provided for running full suite
+          ## TODO: I want to have a possibility to NOT ignore those test if I wish to - by adding additional input to github actions, for example
           sed -i '/<testsuites>/i\<groups>\<exclude>\<group>integrationIgnore<\/group><\/exclude><\/groups>' "$FILE"
           echo "\nIgnore group `integrationIgnore` has been added to $FILE \n"
           


### PR DESCRIPTION
### Description (*)
Allow skipping failed tests with the possibility in the future to run the full suite.

### Related Pull Requests
https://github.com/mage-os/mageos-magento2/pull/92

### Fixed Issues (if relevant)
https://github.com/mage-os/mageos-magento2/issues/80