### PR TITLE
fix: coding-standard-baseline: Run baseline test on modified files only (fixes #227)

### DIFF
--- a/coding-standard-baseline/action.yml
+++ b/coding-standard-baseline/action.yml
@@ -70,6 +70,8 @@ runs:
       with:
         list-files: shell
         filters: |
+          baseline:
+            - modified: '**/**.{php,phtml,graphqls,less,css,html,xml,js}'
           phpcs:
             - added|modified: '**/**.{php,phtml,graphqls,less,css,html,xml,js}'
 
@@ -78,7 +80,7 @@ runs:
       shell: bash
       run: |
         echo "One or more files relevant to PHPCS have changed."
-        echo "List all the files that have changed: ${{ steps.filter.outputs.phpcs_files }}"
+        echo "List all the files that have been added or changed: ${{ steps.filter.outputs.phpcs_files }}"
 
     - name: Setup PHP
       if: steps.filter.outputs.phpcs == 'true'
@@ -115,17 +117,17 @@ runs:
     - name: Create phpcs.baseline.xml from base
       shell: bash
       working-directory: base
-      if: steps.filter.outputs.phpcs == 'true'
+      if: steps.filter.outputs.baseline == 'true'
       run: |
         php ${{ github.workspace }}/magento-coding-standard/vendor/bin/phpcs --standard=Magento2 \
         $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
         $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
         $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \
         --report=\\DR\\CodeSnifferBaseline\\Reports\\Baseline --report-file=phpcs.baseline.xml \
-        ${{ steps.filter.outputs.phpcs_files }} || /bin/true
+        ${{ steps.filter.outputs.baseline_files }} || /bin/true
 
     - name: Copy baseline to head
-      if: steps.filter.outputs.phpcs == 'true'
+      if: steps.filter.outputs.baseline == 'true'
       shell: bash
       run: |
         cp ${{ github.workspace }}/base/phpcs.baseline.xml ${{ github.workspace }}/magento-coding-standard/phpcs.baseline.xml
@@ -133,7 +135,7 @@ runs:
     # Since we ran phpcs in the base folder, the files in phpcs.baseline.xml contain the base folder in the path.
     # We need to remove /base/ so that the phpcs can locate the correct files.
     - name: Remove base dir from phpcs baseline
-      if: steps.filter.outputs.phpcs == 'true'
+      if: steps.filter.outputs.baseline == 'true'
       shell: bash
       run: |
         sed -i "s|/base/|/|" ${{ github.workspace }}/magento-coding-standard/phpcs.baseline.xml


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #227 

Current behavior is for the PHPCS baseline test to fail with 'no such file' when adding files, because the new file doesn't exist in the baseline files.

## What is the new behavior?

This PR fixes it by adding a separate filter list of modified files only, and using that for the baseline test and follow up actions. The final PHPCS test is still run on all added and modified files. This is proper behavior, since the baseline is to exclude any preexisting standards errors, and new files would not have any preexisting standards errors -- only modified ones would. But all added or modified files must be checked for code standards.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
