### PR TITLE
Fixing failing eComscan workflows

### DIFF
--- a/.github/workflows/sansec-ecomscan.yml
+++ b/.github/workflows/sansec-ecomscan.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   run-ecomscan:
+    # Skip if it's a push event on a PR (it can't access secrets)
+    if: github.event.pull_request == null || github.event_name != 'push'
     name: Run Sansec eComscan
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
I took another look at https://github.com/mage-os/github-actions/pull/252/checks and I've noticed that there are 2 ecomscan workflows running there! One is failing and the other one is successful.

The failing one comes from the “push” event, which probably doesn't have access to secrets (when running in a PR).

This PR should skip the push even when the action gets called inside a PR.