### PR TITLE
fix: run integration tests on php-debug container

### DIFF
--- a/.github/workflows/full-integration-tests.yaml
+++ b/.github/workflows/full-integration-tests.yaml
@@ -243,7 +243,7 @@ jobs:
         run: |
           export WARDEN="$(dirname $(pwd))/warden/bin/warden"
           # Important: Run the custom "Magento Integration Tests" test suite, which runs all other test suites
-          ${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-fpm ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite 'Magento Integration Tests' --log-junit=../../../phpunit-output/junit/res-log.xml --coverage-html=../../../phpunit-output/coverage-html/res.html
+          ${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-debug ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite 'Magento Integration Tests' --log-junit=../../../phpunit-output/junit/res-log.xml --coverage-html=../../../phpunit-output/coverage-html/res.html
 
   rum-memory-integration-tests:
     needs: [ matrix-calculator ]

--- a/.github/workflows/full-integration-tests.yaml
+++ b/.github/workflows/full-integration-tests.yaml
@@ -243,7 +243,7 @@ jobs:
         run: |
           export WARDEN="$(dirname $(pwd))/warden/bin/warden"
           # Important: Run the custom "Magento Integration Tests" test suite, which runs all other test suites
-          ${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-debug ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite 'Magento Integration Tests' --log-junit=../../../phpunit-output/junit/res-log.xml --coverage-html=../../../phpunit-output/coverage-html/res.html
+          ${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-fpm ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite 'Magento Integration Tests' --log-junit=../../../phpunit-output/junit/res-log.xml --coverage-html=../../../phpunit-output/coverage-html/res.html
 
   rum-memory-integration-tests:
     needs: [ matrix-calculator ]

--- a/.github/workflows/full-integration-tests.yaml
+++ b/.github/workflows/full-integration-tests.yaml
@@ -243,7 +243,7 @@ jobs:
         run: |
           export WARDEN="$(dirname $(pwd))/warden/bin/warden"
           # Important: Run the custom "Magento Integration Tests" test suite, which runs all other test suites
-          ${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-fpm ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite 'Magento Integration Tests' --log-junit=../../../phpunit-output/junit/res-log.xml --coverage-html=../../../phpunit-output/coverage-html/res.html
+          ${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-fpm ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite 'Magento Integration Tests' --log-junit=../../../phpunit-output/junit/res-log.xml
 
   rum-memory-integration-tests:
     needs: [ matrix-calculator ]

--- a/nx-integration-tests-setup/action.yml
+++ b/nx-integration-tests-setup/action.yml
@@ -91,8 +91,8 @@ runs:
       shell: bash
       run: |
         npm run generate-workspace -- --commands=test:unit,test:integration \
-          --test:unit='if [ -d {{ MODULE_PATH }}Test/Unit ]; then ${WARDEN} env exec -T php-fpm ./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml {{ MODULE_PATH }}Test/Unit; else echo "{{ MODULE_NAME }} has no unit test; fi' \
-          --test:integration='${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-fpm ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite '"'"'Magento Integration Tests Real Suite'"'"' --filter='"'"'/Magento/{{ MODULE_DIRECTORY }}/|Magento\\{{ MODULE_DIRECTORY }}'"'"' --log-junit=../../../phpunit-output/junit/{{ MODULE_DIRECTORY }}.xml --coverage-html=../../../phpunit-output/coverage-html/{{ MODULE_DIRECTORY }}'
+          --test:unit='if [ -d {{ MODULE_PATH }}Test/Unit ]; then ${WARDEN} env exec -T php-debug ./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml {{ MODULE_PATH }}Test/Unit; else echo "{{ MODULE_NAME }} has no unit test; fi' \
+          --test:integration='${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-debug ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite '"'"'Magento Integration Tests Real Suite'"'"' --filter='"'"'/Magento/{{ MODULE_DIRECTORY }}/|Magento\\{{ MODULE_DIRECTORY }}'"'"' --log-junit=../../../phpunit-output/junit/{{ MODULE_DIRECTORY }}.xml --coverage-html=../../../phpunit-output/coverage-html/{{ MODULE_DIRECTORY }}'
 
     - name: Print Affected
       working-directory: ./main

--- a/nx-integration-tests-setup/action.yml
+++ b/nx-integration-tests-setup/action.yml
@@ -92,7 +92,7 @@ runs:
       run: |
         npm run generate-workspace -- --commands=test:unit,test:integration \
           --test:unit='if [ -d {{ MODULE_PATH }}Test/Unit ]; then ${WARDEN} env exec -T php-fpm ./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml {{ MODULE_PATH }}Test/Unit; else echo "{{ MODULE_NAME }} has no unit test; fi' \
-          --test:integration='${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-debug ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite '"'"'Magento Integration Tests Real Suite'"'"' --filter='"'"'/Magento/{{ MODULE_DIRECTORY }}/|Magento\\{{ MODULE_DIRECTORY }}'"'"' --log-junit=../../../phpunit-output/junit/{{ MODULE_DIRECTORY }}.xml --coverage-html=../../../phpunit-output/coverage-html/{{ MODULE_DIRECTORY }}'
+          --test:integration='${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-fpm ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite '"'"'Magento Integration Tests Real Suite'"'"' --filter='"'"'/Magento/{{ MODULE_DIRECTORY }}/|Magento\\{{ MODULE_DIRECTORY }}'"'"' --log-junit=../../../phpunit-output/junit/{{ MODULE_DIRECTORY }}.xml --coverage-html=../../../phpunit-output/coverage-html/{{ MODULE_DIRECTORY }}'
 
     - name: Print Affected
       working-directory: ./main

--- a/nx-integration-tests-setup/action.yml
+++ b/nx-integration-tests-setup/action.yml
@@ -91,7 +91,7 @@ runs:
       shell: bash
       run: |
         npm run generate-workspace -- --commands=test:unit,test:integration \
-          --test:unit='if [ -d {{ MODULE_PATH }}Test/Unit ]; then ${WARDEN} env exec -T php-debug ./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml {{ MODULE_PATH }}Test/Unit; else echo "{{ MODULE_NAME }} has no unit test; fi' \
+          --test:unit='if [ -d {{ MODULE_PATH }}Test/Unit ]; then ${WARDEN} env exec -T php-fpm ./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml {{ MODULE_PATH }}Test/Unit; else echo "{{ MODULE_NAME }} has no unit test; fi' \
           --test:integration='${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-debug ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite '"'"'Magento Integration Tests Real Suite'"'"' --filter='"'"'/Magento/{{ MODULE_DIRECTORY }}/|Magento\\{{ MODULE_DIRECTORY }}'"'"' --log-junit=../../../phpunit-output/junit/{{ MODULE_DIRECTORY }}.xml --coverage-html=../../../phpunit-output/coverage-html/{{ MODULE_DIRECTORY }}'
 
     - name: Print Affected

--- a/nx-integration-tests-setup/action.yml
+++ b/nx-integration-tests-setup/action.yml
@@ -92,7 +92,7 @@ runs:
       run: |
         npm run generate-workspace -- --commands=test:unit,test:integration \
           --test:unit='if [ -d {{ MODULE_PATH }}Test/Unit ]; then ${WARDEN} env exec -T php-fpm ./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml {{ MODULE_PATH }}Test/Unit; else echo "{{ MODULE_NAME }} has no unit test; fi' \
-          --test:integration='${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-fpm ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite '"'"'Magento Integration Tests Real Suite'"'"' --filter='"'"'/Magento/{{ MODULE_DIRECTORY }}/|Magento\\{{ MODULE_DIRECTORY }}'"'"' --log-junit=../../../phpunit-output/junit/{{ MODULE_DIRECTORY }}.xml --coverage-html=../../../phpunit-output/coverage-html/{{ MODULE_DIRECTORY }}'
+          --test:integration='${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-fpm ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite '"'"'Magento Integration Tests Real Suite'"'"' --filter='"'"'/Magento/{{ MODULE_DIRECTORY }}/|Magento\\{{ MODULE_DIRECTORY }}'"'"' --log-junit=../../../phpunit-output/junit/{{ MODULE_DIRECTORY }}.xml'
 
     - name: Print Affected
       working-directory: ./main

--- a/warden/integration-tests/action.yml
+++ b/warden/integration-tests/action.yml
@@ -142,7 +142,7 @@ runs:
       shell: bash
       run: |
         export WARDEN="$(dirname $(pwd))/warden/bin/warden"
-        ${WARDEN} env exec -T php-debug /bin/bash -c "cd ./dev/tests/integration
+        ${WARDEN} env exec -T php-fpm /bin/bash -c "cd ./dev/tests/integration
           echo -e '\033[32mRun Memory Tests\033[0m'
           php ../../../vendor/bin/phpunit \
             --configuration phpunit.xml.dist \
@@ -158,7 +158,7 @@ runs:
       shell: bash
       run: |
         export WARDEN="$(dirname $(pwd))/warden/bin/warden"
-        ${WARDEN} env exec -T php-debug /bin/bash -c "cd ./dev/tests/integration
+        ${WARDEN} env exec -T php-fpm /bin/bash -c "cd ./dev/tests/integration
           echo -e '\033[32mRun Magento Integration Tests\033[0m'
           php ../../../vendor/bin/phpunit \
               --configuration phpunit.xml.dist \
@@ -174,7 +174,7 @@ runs:
       shell: bash
       run: |
         export WARDEN="$(dirname $(pwd))/warden/bin/warden"
-        ${WARDEN} env exec -T php-debug /bin/bash -c "cd ./dev/tests/integration
+        ${WARDEN} env exec -T php-fpm /bin/bash -c "cd ./dev/tests/integration
               echo -e '\033[32mRun Magento Integration Tests Real Suite\033[0m'
               php ../../../vendor/bin/phpunit \
               --configuration phpunit.xml.dist \

--- a/warden/integration-tests/action.yml
+++ b/warden/integration-tests/action.yml
@@ -146,9 +146,7 @@ runs:
           echo -e '\033[32mRun Memory Tests\033[0m'
           php ../../../vendor/bin/phpunit \
             --configuration phpunit.xml.dist \
-            --coverage-clover=coverage.xml \
             --log-junit=test-results.xml \
-            --coverage-html=coverage \
             --testsuite 'Memory Usage Tests'
         "
 
@@ -162,9 +160,7 @@ runs:
           echo -e '\033[32mRun Magento Integration Tests\033[0m'
           php ../../../vendor/bin/phpunit \
               --configuration phpunit.xml.dist \
-              --coverage-clover=coverage.xml \
               --log-junit=test-results.xml \
-              --coverage-html=coverage \
               --testsuite 'Magento Integration Tests'
         "
 
@@ -178,8 +174,6 @@ runs:
               echo -e '\033[32mRun Magento Integration Tests Real Suite\033[0m'
               php ../../../vendor/bin/phpunit \
               --configuration phpunit.xml.dist \
-              --coverage-clover=coverage.xml \
               --log-junit=test-results.xml \
-              --coverage-html=coverage \
               --testsuite 'Magento Integration Tests Real Suite'
         "

--- a/warden/integration-tests/action.yml
+++ b/warden/integration-tests/action.yml
@@ -142,7 +142,7 @@ runs:
       shell: bash
       run: |
         export WARDEN="$(dirname $(pwd))/warden/bin/warden"
-        ${WARDEN} env exec -T php-fpm /bin/bash -c "cd ./dev/tests/integration
+        ${WARDEN} env exec -T php-debug /bin/bash -c "cd ./dev/tests/integration
           echo -e '\033[32mRun Memory Tests\033[0m'
           php ../../../vendor/bin/phpunit \
             --configuration phpunit.xml.dist \
@@ -158,7 +158,7 @@ runs:
       shell: bash
       run: |
         export WARDEN="$(dirname $(pwd))/warden/bin/warden"
-        ${WARDEN} env exec -T php-fpm /bin/bash -c "cd ./dev/tests/integration
+        ${WARDEN} env exec -T php-debug /bin/bash -c "cd ./dev/tests/integration
           echo -e '\033[32mRun Magento Integration Tests\033[0m'
           php ../../../vendor/bin/phpunit \
               --configuration phpunit.xml.dist \
@@ -174,7 +174,7 @@ runs:
       shell: bash
       run: |
         export WARDEN="$(dirname $(pwd))/warden/bin/warden"
-        ${WARDEN} env exec -T php-fpm /bin/bash -c "cd ./dev/tests/integration
+        ${WARDEN} env exec -T php-debug /bin/bash -c "cd ./dev/tests/integration
               echo -e '\033[32mRun Magento Integration Tests Real Suite\033[0m'
               php ../../../vendor/bin/phpunit \
               --configuration phpunit.xml.dist \


### PR DESCRIPTION
Full integration test suite currently throws an error: https://github.com/mage-os/mageos-magento2/actions/runs/14297962741/job/40067613645 "No code coverage driver available"

~Francis Gallagher suggested changing them from the `php-fpm` container to `php-debug`. This PR does that.~

Code coverage is not needed or used by the integration test suite/actions currently, so this removes the coverage options.