### PR TITLE
feat(supported-version): revise v2.4.6-p14 eol for adjustments from a…

### DIFF
--- a/supported-version/src/kind/get-currently-supported.spec.ts
+++ b/supported-version/src/kind/get-currently-supported.spec.ts
@@ -83,7 +83,8 @@ describe('getCurrentlySupportedVersions for magento-open-source', () => {
             'magento/project-community-edition:2.4.7-p9',
             'magento/project-community-edition:2.4.8-p4',
         ]],
-        ['2026-03-15T00:00:00Z', 'Day after v2.4.6 EoL', [
+        ['2026-03-15T00:00:00Z', 'Day after original v2.4.6-p14 release', [
+            'magento/project-community-edition:2.4.6-p14',
             'magento/project-community-edition:2.4.7-p9',
             'magento/project-community-edition:2.4.8-p4',
         ]],

--- a/supported-version/src/versions/magento-open-source/individual.json
+++ b/supported-version/src/versions/magento-open-source/individual.json
@@ -795,7 +795,7 @@
         "nginx": "nginx:1.22",
         "os": "ubuntu-latest",
         "release": "2026-03-10T00:00:00+0000",
-        "eol": "2026-03-14T00:00:00+0000"
+        "eol": "2026-08-11T00:00:00+0000"
     },
     "magento/project-community-edition:2.4.7": {
         "magento": "magento/project-community-edition:2.4.7",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

`magento/project-community-edition:2.4.6-p14` has an incorrect EoL date of `2026-03-14` in the version data, causing it to be excluded from `currently-supported` results just 4 days after its release on `2026-03-10`.

Fixes: N/A


## What is the new behavior?

The EoL date for `2.4.6-p14` is corrected to `2026-08-11`. The `2026-03-15` spec test is updated to reflect that `2.4.6-p14` remains supported on that date.


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
