### PR TITLE
fix(cache-magento): address `set-output` deprecation (#231)

### DIFF
--- a/cache-magento/action.yml
+++ b/cache-magento/action.yml
@@ -26,11 +26,11 @@ runs:
       run: |
         echo "dir=$(composer config cache-files-dir --global)" >> $GITHUB_OUTPUT
 
-    - run: echo "::set-output name=version::$(php -v | awk 'NR==1{print $2}')"
+    - run: echo "version=$(php -v | awk 'NR==1{print $2}')" >> "$GITHUB_OUTPUT"
       shell: bash
       id: cache-magento-get-php-version
 
-    - run: echo "::set-output name=version::$(composer --version | awk '{print $3}')"
+    - run: echo "version=$(composer --version | awk '{print $3}')" >> "$GITHUB_OUTPUT"
       shell: bash
       name: Compute Composer Version
       id: cache-magento-get-composer-version


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Annoying set-output logs.

Fixes: N/A


## What is the new behavior?
No more set-output logs.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
