### PR TITLE
refactor(cache-magento): remove extraneous store input

### DIFF
--- a/cache-magento/README.md
+++ b/cache-magento/README.md
@@ -10,7 +10,6 @@ See the [action.yml](./action.yml)
 | Input              | Description                                                                            | Required | Default      |
 | ------------------ | -------------------------------------------------------------------------------------- | -------- | ------------ |
 | composer_cache_key | A key to version the composer cache. Can be incremented if you need to bust the cache. | false    | '__mageos' |
-| mode               | "The mode for setup, one of: `extension` or `store`."                                  | true     | N/A          |
 
 ### Usage
 
@@ -31,8 +30,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: mage-os/github-actions/cache-magento@main
-      with:
-        mode: 'store'
       id: cache-magento
 
     - run: composer install

--- a/cache-magento/action.yml
+++ b/cache-magento/action.yml
@@ -8,10 +8,6 @@ inputs:
     default: "__mageos"
     description: A key to version the composer cache. Can be incremented if you need to bust the cache.
 
-  mode:
-    required: true
-    description: "The mode for setup, one of: `extension` or `store`."
-
 outputs:
   cache-hit:
     description: "A boolean value to indicate an exact match was found for the key"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, `cache-magento` has an extraneous `mode` arg that does nothing. 

Fixes: N/A


## What is the new behavior?
This removes the extraneous arg.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
