### PR TITLE
feat(coding-standard)!: simplify action architecture

### DIFF
--- a/.github/workflows/_internal-coding-standard.yaml
+++ b/.github/workflows/_internal-coding-standard.yaml
@@ -32,14 +32,15 @@ on:
 
 jobs:
   compute_matrix:
+    if: "!startsWith(github.head_ref, 'release-please')"
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.supported-version.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./supported-version
         with:
-          kind: all
+          kind: currently-supported
         id: supported-version
       - run: echo ${{ steps.supported-version.outputs.matrix }}
 
@@ -50,10 +51,15 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v${{ matrix.composer }}
+          coverage: none
+
       - uses: './coding-standard'
         with:
           version: ${{ github.event.inputs.version || '*' }}
           path: ${{ github.event.inputs.path || '_test/demo-package' }}
-          composer_version: ${{ matrix.composer }}
-          php_version: ${{ matrix.php }}

--- a/coding-standard/README.md
+++ b/coding-standard/README.md
@@ -2,11 +2,16 @@
 
 A Github Action that runs the Magento Coding Standard.
 
+> [!WARNING]
+> This action is only compatible with Magento v2.4.4+.
+
 ## Inputs
 
 See the [action.yml](./action.yml)
 
 ## Usage
+
+The caller is responsible for checking out the repository and setting up PHP before calling this action.
 
 ```yml
 name: Coding Standard
@@ -23,10 +28,18 @@ jobs:
   coding-standard:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v6
+
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.3'
+        tools: composer:v2
+        coverage: none
+
     - uses: mage-os/github-actions/coding-standard@main
       with:
+        path: app/code # Optional, defaults to .
         version: 25 # Optional, will use the latest if omitted.
-        path: app/code # Optional, will be used when event is not a pull request.
         severity: 8 # Optional, will use phpcs default of 5 if not specified.
         warning_severity: 4 # Optional, will use severity value if not specified.
         error_severity: 7 # Optional, will use severity value if not specified.

--- a/coding-standard/action.yml
+++ b/coding-standard/action.yml
@@ -3,35 +3,25 @@ author: "Graycore"
 description: "A Github Action that runs the Magento Coding Standard."
 
 inputs:
-  php_version:
-    required: true
-    default: "8.3"
-    description: "PHP version used to do the coding standard check."
-
-  composer_version:
-    required: true
-    default: "2"
-    description: "The version of composer to use."
-
   path:
     required: true
-    default: 'app/code'
-    description: "The directory (relative to the project root) in which the coding standard will be checked. Used when the event is not a pull request."
+    default: '.'
+    description: "The directory containing the code to check."
 
   version:
     required: false
     description: "The version of the coding standard to use. If not provided, will use the latest version."
-    
+
   severity:
     required: false
     default: ""
     description: "The minimum severity required to display an error or warning (default: 5)"
-  
+
   warning_severity:
     required: false
     default: ""
     description: "The minimum severity required to display a warning"
-  
+
   error_severity:
     required: false
     default: ""
@@ -42,72 +32,90 @@ inputs:
     default: 'false'
     required: false
 
+  composer_auth:
+    required: false
+    default: ""
+    description: "Composer authentication credentials (contents of auth.json as a JSON string)"
+
 runs:
   using: composite
   steps:
-    - name: Checkout Project
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        path: project
-
-    - name: Create Standard Directory
+    - name: Check if Coding Standard is already installed
+      id: check-installed
       shell: bash
-      run: mkdir standard
-
-    - name: Set PHP Version
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ inputs.php_version }}
-        tools: composer:v${{ inputs.composer_version }}
-        coverage: none
+      working-directory: ${{ inputs.path }}
+      run: |
+        if [ -d "vendor/magento/magento-coding-standard" ] || [ -d "vendor/mage-os/magento-coding-standard" ]; then
+          echo "installed=true" >> $GITHUB_OUTPUT
+        else
+          echo "installed=false" >> $GITHUB_OUTPUT
+        fi
 
     - name: Get Composer Version
       uses: mage-os/github-actions/get-composer-version@main
       id: get-composer-version
+      if: steps.check-installed.outputs.installed != 'true'
 
     - name: Check if allow-plugins option is available for this version of composer
       uses: mage-os/github-actions/semver-compare@main
+      id: is-allow-plugins-available
+      if: steps.check-installed.outputs.installed != 'true'
       with:
         version: 2.2
         compare_against: ${{ steps.get-composer-version.outputs.version }}
-      id: is-allow-plugins-available
 
     - name: Enable dealerdirect/phpcodesniffer-composer-installer plugin
       shell: bash
-      working-directory: standard
-      run: composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer  true --global
-      if: steps.is-allow-plugins-available.outputs.result < 1
+      working-directory: ${{ inputs.path }}
+      run: composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true --global
+      if: steps.check-installed.outputs.installed != 'true' && steps.is-allow-plugins-available.outputs.result < 1
 
     - name: Install Coding Standard
       shell: bash
-      working-directory: standard
-      run: composer require "magento/magento-coding-standard:${{ inputs.version || '*' }}"
+      working-directory: ${{ inputs.path }}
+      run: composer require "magento/magento-coding-standard:${{ inputs.version || '*' }}" "magento/php-compatibility-fork"
+      if: steps.check-installed.outputs.installed != 'true'
+      env:
+        COMPOSER_AUTH: ${{ inputs.composer_auth }}
 
     - name: Register Coding Standard
       shell: bash
-      working-directory: standard
-      run: vendor/bin/phpcs --config-set installed_paths ${{ github.workspace }}/standard/vendor/magento/magento-coding-standard,${{ github.workspace }}/standard/vendor/magento/php-compatibility-fork,${{ github.workspace }}/standard/vendor/phpcompatibility/php-compatibility
+      working-directory: ${{ inputs.path }}
+      run: |
+        if [ -d vendor/magento/magento-coding-standard ]; then
+          CODING_STANDARD_VENDOR=magento
+        elif [ -d vendor/mage-os/magento-coding-standard ]; then
+          CODING_STANDARD_VENDOR=mage-os
+        else
+          echo "No magento-coding-standard directory found under vendor/magento or vendor/mage-os."
+          echo "Trusting dealerdirect/phpcodesniffer-composer-installer to have registered installed_paths."
+          exit 0
+        fi
+        vendor/bin/phpcs --config-set installed_paths \
+          "vendor/${CODING_STANDARD_VENDOR}/magento-coding-standard,vendor/${CODING_STANDARD_VENDOR}/php-compatibility-fork"
+      if: steps.check-installed.outputs.installed != 'true'
 
     - name: Set ignore warnings flag
       shell: bash
-      working-directory: standard
+      working-directory: ${{ inputs.path }}
       run: vendor/bin/phpcs --config-set ignore_warnings_on_exit 1
       if: inputs.ignore_warnings == 'true'
 
-    - name: Get Changed Files
-      shell: bash
-      working-directory: project
-      id: changed-files
-      run: echo "files=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | xargs)" >> $GITHUB_OUTPUT
-      if: github.event_name == 'pull_request'
-
     - name: Coding Standard Check
       shell: bash
+      working-directory: ${{ inputs.path }}
       run: |
-        ../standard/vendor/bin/phpcs --standard=Magento2 \
-        $([ -n "${{ inputs.severity }}" ] && echo "--severity=${{ inputs.severity }}") \
-        $([ -n "${{ inputs.warning_severity }}" ] && echo "--warning-severity=${{ inputs.warning_severity }}") \
-        $([ -n "${{ inputs.error_severity }}" ] && echo "--error-severity=${{ inputs.error_severity }}") \
-        ${{ github.event_name == 'pull_request' && steps.changed-files.outputs.files || inputs.path }}
-      working-directory: project
+        FLAGS=()
+        [ -n "${{ inputs.severity }}" ] && FLAGS+=(--severity=${{ inputs.severity }}) || true
+        [ -n "${{ inputs.warning_severity }}" ] && FLAGS+=(--warning-severity=${{ inputs.warning_severity }}) || true
+        [ -n "${{ inputs.error_severity }}" ] && FLAGS+=(--error-severity=${{ inputs.error_severity }}) || true
+
+        if [ -f .phpcs.xml ] || [ -f phpcs.xml ] || [ -f .phpcs.xml.dist ] || [ -f phpcs.xml.dist ]; then
+          vendor/bin/phpcs "${FLAGS[@]}" .
+        else
+          vendor/bin/phpcs --standard=Magento2 --ignore=*vendor/* "${FLAGS[@]}" .
+        fi
+
+branding:
+  icon: "code"
+  color: "green"


### PR DESCRIPTION
## PR description

## Summary

- Aligns `coding-standard/action.yml` with the graycore source of truth per [#331](https://github.com/mage-os/github-actions/issues/331)
- Removes embedded PHP setup and project checkout from the action — callers are now responsible for PHP/composer setup (matching graycore's lean architecture)
- Adds `composer_auth` input, already-installed skip logic, `vendor/mage-os` path support, `php-compatibility-fork`, improved flags handling, and branding
- Updates `_internal-coding-standard.yaml` to set up PHP in the workflow and use `currently-supported` matrix

## Breaking changes

- `php_version` and `composer_version` inputs removed — callers must add a `shivammathur/setup-php` step before invoking this action
- `path` default changed from `app/code` to `.`


