### PR TITLE
ci: expose nginx port via warden override for e2e access

### DIFF
--- a/warden/setup-environment/action.yml
+++ b/warden/setup-environment/action.yml
@@ -195,6 +195,23 @@ runs:
 
         echo ".env created"
         cat .env
+        
+    - name: Expose nginx for CI
+      working-directory: ${{ inputs.base_directory }}
+      shell: bash
+      run: |
+        mkdir -p .warden
+    
+        cat <<EOF > .warden/warden-env.yml
+        version: "3.5"
+        services:
+          nginx:
+            ports:
+              - "8080:80"
+        EOF
+    
+        echo "Warden override created"
+        cat .warden/warden-env.yml
 
     - name: Warden svc up && Warden env up
       working-directory: ${{ inputs.base_directory }}
@@ -238,7 +255,7 @@ runs:
         done
         echo "HEALTHY: ${HEALTHY}"
         exit ${HEALTHY}
-        
+
     - name: composer install run
       working-directory: ${{ inputs.base_directory }}
       shell: bash


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (not applicable)
- [ ] Docs have been added / updated (not applicable)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

The Warden environment starts successfully in CI, but no HTTP service is exposed to the GitHub Actions runner.

As a result, e2e tests cannot reach the application (no accessible localhost endpoint).


## What is the new behavior?

Adds a Warden override (`.warden/warden-env.yml`) to expose the web service on `localhost:8080`.

This provides a reachable HTTP endpoint for e2e tests in CI.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

This change assumes nginx is the entrypoint exposed by Warden.

If Warden routes traffic via Traefik in CI, exposing Traefik instead may be more appropriate. This PR establishes a baseline to validate HTTP reachability.