### PR TITLE
feat(integration): compute services from matrix

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -59,66 +59,10 @@ on:
 jobs:
   integration_test:
     runs-on:  ${{ matrix.os }}
+    services: ${{ matrix.services }}
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix: ${{ fromJSON(inputs.matrix) }}
-    services:
-      elasticsearch:
-        image: ${{ matrix.elasticsearch || '' }}
-        env:
-          # By default, ElasticSearch refuses to spawn in single node configuration, as it expects redundancy.
-          # This is a dev environment, so redundancy is just wasteful.
-          discovery.type: single-node
-          # Disable HTTPS and password authentication
-          # this is a local dev environment, so the added CA chain complexity is an extreme overkill
-          xpack.security.enabled: false
-          xpack.security.http.ssl.enabled: false
-          xpack.security.transport.ssl.enabled: false
-
-        options: >-
-          --health-cmd "curl http://localhost:9200/_cluster/health"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-        ports:
-          - 9200:9200
-
-      opensearch:
-        image: ${{ matrix.opensearch || '' }}
-        env:
-          # By default, ElasticSearch refuses to spawn in single node configuration, as it expects redundancy.
-          # This is a dev environment, so redundancy is just wasteful.
-          discovery.type: single-node
-          # Disable HTTPS and password authentication
-          DISABLE_INSTALL_DEMO_CONFIG: true
-          DISABLE_SECURITY_PLUGIN: true
-
-        options: >-
-          --health-cmd "curl http://localhost:9200/_cluster/health"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-        ports:
-          - 9200:9200
-
-      mysql:
-        image: ${{ matrix.mysql }}
-        env:
-          MYSQL_DATABASE: magento_integration_tests
-          MYSQL_USER: user
-          MYSQL_PASSWORD: password
-          MYSQL_ROOT_PASSWORD: rootpassword
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
-      rabbitmq:
-        image: ${{ matrix.rabbitmq }}
-        env:
-          RABBITMQ_DEFAULT_USER: guest
-          RABBITMQ_DEFAULT_PASS: guest
-        ports:
-          - 5672:5672
     steps:
     - uses: actions/checkout@v4
     - name: Set PHP Version


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, the `integration` workflow uses hard-coded services which only happenstance work across the matrix of service versions that we test against.

For example, if between opensearch 1 / 2 / 3, they decided to change the environment variables around (they did):

```
DISABLE_INSTALL_DEMO_CONFIG: true
DISABLE_SECURITY_PLUGIN: true
```

Then the integration tests would break for only some versions.

Touches: https://github.com/mage-os/github-actions/issues/338


## What is the new behavior?
Instead, we derive the services matrix in `supported-version` as of #353 and now we use it here.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

I don't expect this to be breaking. However, if people are using consistent versions. 

However, scenarios like: `supported-version@1.0.0` with `integration@main` would break.

The `generate-mirror-repo-js` depends on this action it should be validated against this PR before merge. I reviewed other dependents:

<img width="1037" height="405" alt="image" src="https://github.com/user-attachments/assets/e1dc95ec-7556-47f3-b824-3ba0b298226a" />


and the UI is inaccurate the other repos don't use this action.