### PR TITLE
Align setup-magento action with upstream defaults

### DIFF
--- a/setup-magento/action.yml
+++ b/setup-magento/action.yml
@@ -5,7 +5,7 @@ description: "This action sets up a Magento instance for further actions like ru
 inputs:
   php-version:
     description: "Setup PHP version."
-    default: "8.3"
+    default: "8.4"
     required: true
 
   tools:
@@ -27,7 +27,7 @@ inputs:
 
   magento_version: 
     required: false
-    default: '~2.4.7-p4'
+    default: '~2.4.8-p3'
     description: "The version of Magento to use. This is only relevant if you are testing an extension."
 
   apply_fixes: 


### PR DESCRIPTION
Use this:

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: [https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit](https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit)
* [ ] Tests for the changes have been added (not applicable)
* [ ] Docs have been added / updated (not applicable)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `setup-magento` action diverged from the upstream implementation:

* default PHP version was still set to 8.3
* default Magento version was outdated
* `composer_auth` input handling was missing
* `COMPOSER_AUTH` was not passed to composer-related steps

Fixes: N/A

## What is the new behavior?

Align `setup-magento/action.yml` with upstream defaults by:

* bumping the default PHP version to 8.4
* updating the default Magento version
* adding `composer_auth` input support
* forwarding `COMPOSER_AUTH` to composer-related steps

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This change assumes environments are not relying on Traefik-specific routing behaviour.
