### PR TITLE
Add composer_auth support to setup-magento

### DIFF
--- a/setup-magento/action.yml
+++ b/setup-magento/action.yml
@@ -45,6 +45,11 @@ inputs:
     default: "."
     description: "The working directory to run the action in."
 
+  composer_auth:
+    required: false
+    default: ""
+    description: "Composer authentication credentials (contents of auth.json as a JSON string)"
+
 outputs:
   path:
     description: "The absolute path to where Magento was set up."
@@ -83,6 +88,8 @@ runs:
       shell: bash
       name: Create Magento ${{ inputs.magento_version }} Project
       if: inputs.mode == 'extension'
+      env:
+        COMPOSER_AUTH: ${{ inputs.composer_auth }}
 
     - uses: mage-os/github-actions/fix-magento-install@main
       name: Fix Magento Out of Box Install Issues


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [ ] Other... Please describe:

## What is the current behavior?

Currently, Composer authentication must be configured manually in workflow steps using `COMPOSER_AUTH`.

`setup-magento` does not expose a dedicated `composer_auth` input or propagate authentication credentials internally to Composer execution steps.

Fixes: N/A

## What is the new behavior?

Adds an optional `composer_auth` input to `setup-magento` and propagates `COMPOSER_AUTH` to the internal Composer `create-project` step.

This enables authenticated Magento repository installs while preserving anonymous Mage-OS installs.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

This change keeps Composer authentication optional to avoid impacting existing Mage-OS workflows using the public Mage-OS mirror.
