### PR TITLE
refactor(setup-di-compile) port restored Graycore implementation

### DIFF
--- a/setup-di-compile/action.yml
+++ b/setup-di-compile/action.yml
@@ -1,58 +1,26 @@
 name: "Magento compilation (setup:di:compile)"
 author: "MageOS"
-description: "A Github Action that runs bin/magento setup:di:compile."
+description: "A GitHub Action that runs bin/magento setup:di:compile."
 
 inputs:
-  php_version:
-    required: true
-    default: "8.3"
-    description: "PHP version used to run setup:di:compile."
-
-  composer_version:
-    required: true
-    default: "2"
-    description: "The version of composer to use."
+  path:
+    required: false
+    default: "."
+    description: "Path to the Magento root directory. Accepts the output of the setup-magento action."
 
 runs:
   using: composite
   steps:
-    - name: Checkout Project
-      uses: actions/checkout@v3
-
-    - name: Get changed files that could break compilation
-      uses: tj-actions/changed-files@v39
-      id: changed-files
-      with:
-        files_yaml: |
-          magento:
-            - 'composer.lock'
-            - 'composer.json'
-            - '**/*.php'
-            - '**/*.xml'
-
-    - name: Set PHP Version
-      if: steps.changed-files.outputs.magento_any_changed == 'true'
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ inputs.php_version }}
-        tools: composer:v${{ inputs.composer_version }}
-        coverage: none
-
-    - uses: mage-os/github-actions/cache-magento@main
-      with:
-        mode: 'store'
-
-    - name: Install composer dependencies
-      if: steps.changed-files.outputs.magento_any_changed == 'true'
-      shell: bash
-      run: composer install
-
     - name: Enable all modules
-      if: steps.changed-files.outputs.magento_any_changed == 'true'
+      working-directory: ${{ inputs.path }}
       shell: bash
       run: php bin/magento module:enable --all
 
     - name: Compile
-      if: steps.changed-files.outputs.magento_any_changed == 'true'
+      working-directory: ${{ inputs.path }}
       shell: bash
       run: php bin/magento setup:di:compile
+
+branding:
+  icon: "tool"
+  color: "orange"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
* [ ] Tests for the changes have been added (not applicable)
* [ ] Docs have been added / updated

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [x] Refactoring (no functional changes, no api changes)
* [ ] Code style update (formatting, local variables)
* [ ] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [ ] Other

## What is the current behavior?

`setup-di-compile` currently embeds several workflow orchestration responsibilities directly inside the action:

* repository checkout
* PHP/composer setup
* changed-files detection
* cache handling
* composer dependency installation

This diverges from the restored Graycore implementation and increases maintenance complexity between forks.

Fixes: N/A

## What is the new behavior?

Ports `setup-di-compile` to match the restored Graycore implementation more closely.

The action is now reduced to a focused compilation step that:

* enables Magento modules
* runs `setup:di:compile`
* supports configurable Magento root paths through a new `path` input

Removed from the action:

* embedded `actions/checkout`
* embedded `shivammathur/setup-php`
* `php_version` input
* `composer_version` input
* `tj-actions/changed-files`
* conditional execution logic
* `cache-magento` usage
* embedded `composer install`

## Does this PR introduce a breaking change?

* [x] Yes
* [ ] No

Caller workflows must now explicitly:

* checkout the repository
* setup PHP/composer
* install composer dependencies
* prepare Magento before invoking this action

Example:

```yaml id="l6yl4w"
- uses: actions/checkout@v4

- uses: shivammathur/setup-php@v2
  with:
    php-version: 8.3
    tools: composer:v2
    coverage: none

- run: composer install

- uses: mage-os/github-actions/setup-di-compile@main
```

## Other information

This PR intentionally follows the restored Graycore implementation as closely as possible to reduce divergence between forks and simplify long-term maintenance.
