### PR TITLE
feat(setup-magento)!: change extension working dir to _ghamagento

### DIFF
--- a/setup-magento/action.yml
+++ b/setup-magento/action.yml
@@ -64,7 +64,7 @@ runs:
     - run: |
         MAGENTO_DIRECTORY=""
         if [ "${{ inputs.mode }}" = 'extension' ]; then
-            MAGENTO_DIRECTORY="../magento2"
+            MAGENTO_DIRECTORY="_ghamagento"
         else
             MAGENTO_DIRECTORY="${{ inputs.working-directory }}"
         fi


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added
* [ ] Docs have been added / updated

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other... Please describe:

## What is the current behavior?

In extension mode, `setup-magento` uses:

```bash
../magento2
```

as the Magento working directory.

This differs from upstream Graycore behavior and may cause issues with interactions involving `cache-magento`.

Fixes: N/A

## What is the new behavior?

Ports parity change from:

`graycoreio/github-actions-magento2@a729f8b`

The extension mode working directory is now changed to:

```bash
_ghamagento
```

This aligns Mage-OS behavior with upstream Graycore implementation.

## Does this PR introduce a breaking change?

* [x] Yes
* [ ] No

Consumers relying on the previous hardcoded path:

```bash
../magento2
```

may need to update their workflows.

Consumers using:

```bash
steps.setup-magento.outputs.path
```

should remain unaffected.

## Other information

This is a direct parity port from upstream Graycore implementation.
