### PR TITLE
feat(setup-magento): mkdir app/etc to allow prevent composer plugin crashing 

### DIFF
--- a/setup-magento/action.yml
+++ b/setup-magento/action.yml
@@ -84,6 +84,11 @@ runs:
       name: Create Magento ${{ inputs.magento_version }} Project
       if: inputs.mode == 'extension'
 
+    - run: mkdir -p ${{ steps.setup-magento-compute-directory.outputs.MAGENTO_DIRECTORY }}/app/etc
+      shell: bash
+      name: Ensure app/etc exists for magento composer plugin
+      if: inputs.mode == 'extension'
+
     - uses: mage-os/github-actions/fix-magento-install@main
       name: Fix Magento Out of Box Install Issues
       with:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/mage-os/github-actions/blob/main/CONTRIBUTING.md#commit
* [ ] Tests for the changes have been added (not applicable)
* [ ] Docs have been added / updated (not applicable)

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [ ] Other... Please describe:

## What is the current behavior?

After `composer create-project --no-install`, the Magento directory structure may not yet contain `app/etc`.
Some composer plugin/install flows expect this directory to already exist, which can lead to failures during setup workflows.

Fixes: N/A

## What is the new behavior?

Adds a defensive filesystem initialization step to ensure `app/etc` exists immediately after project creation.
This restores parity with the upstream Graycore implementation and improves setup workflow reliability for extension mode installs.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

This change intentionally mirrors the existing safeguard present in the Graycore implementation of `setup-magento`.
