### PR TITLE
chore(workflows): drop write scope from full-integration-tests

### DIFF
--- a/.github/workflows/full-integration-tests.yaml
+++ b/.github/workflows/full-integration-tests.yaml
@@ -20,7 +20,7 @@ on:
         required: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   matrix-calculator:


### PR DESCRIPTION
## Summary
- `full-integration-tests.yaml` only checks out code and runs tests — no commits, tags, releases, or asset uploads — so `contents: write` is unnecessary.
- This is a `workflow_call` reusable workflow, so the elevated scope also constrained callers' tokens to be granted write scope.
- Dropped to `contents: read`, which is sufficient for `actions/checkout@v4`.

## Test plan
- [ ] Trigger the workflow (via a caller workflow or PR) and confirm checkout + matrix calculation + integration tests all still pass under the reduced scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)