### PR TITLE
fix(workflows): run the Mage-OS Suite testsuite, not a removed one

### DIFF
--- a/.github/workflows/full-integration-tests.yaml
+++ b/.github/workflows/full-integration-tests.yaml
@@ -242,8 +242,8 @@ jobs:
         working-directory: ./main
         run: |
           export WARDEN="$(dirname $(pwd))/warden/bin/warden"
-          # Important: Run the custom "Magento Integration Tests" test suite, which runs all other test suites
-          ${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-fpm ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite 'Magento Integration Tests' --log-junit=../../../phpunit-output/junit/res-log.xml
+          # Run the "Mage-OS Suite" testsuite injected above, which contains this shard's directories
+          ${WARDEN} env exec -T --workdir /var/www/html/dev/tests/integration php-fpm ../../../vendor/bin/phpunit --configuration phpunit.xml.dist --testsuite 'Mage-OS Suite' --log-junit=../../../phpunit-output/junit/res-log.xml
 
   rum-memory-integration-tests:
     needs: [ matrix-calculator ]


### PR DESCRIPTION
## Summary
- The full integration test workflow was producing "No tests executed!" on every shard.
- Root cause: the upstream Magento `phpunit.xml.dist` no longer defines a `Magento Integration Tests` testsuite — only `Memory Usage Tests` and `Magento Integration Tests Real Suite`. The workflow strips both and injects a new `Mage-OS Suite` with the shard's directories, but then ran PHPUnit with `--testsuite 'Magento Integration Tests'`, which matches nothing.
- Fix: invoke `--testsuite 'Mage-OS Suite'` — the suite the workflow actually builds.

The `rum-memory-integration-tests` job is unaffected; it skips the suite-injection step and runs `Memory Usage Tests` against an unmodified `phpunit.xml.dist`.

Observed in run https://github.com/mage-os/mageos-magento2/actions/runs/25951434263 — every shard finished in ~2–3 minutes with "No tests executed!".

## Test plan
- [ ] Manually dispatch `Integration Tests - Full Test Suite` on `mage-os/mageos-magento2` against this branch and confirm shards actually execute tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)