### PR TITLE
fix(workflows): emit <file> for .php entries in Mage-OS testsuite

### DIFF
--- a/.github/workflows/full-integration-tests.yaml
+++ b/.github/workflows/full-integration-tests.yaml
@@ -224,7 +224,16 @@ jobs:
           echo "Debug: $DIRS"
           NEW_TESTSUITE_ENTRY=$(
             echo "<testsuite name=\"Mage-OS Suite\">"
-            IFS=','; for dir in $DIRS; do echo "  <directory>$dir</directory>"; done
+            IFS=','; for dir in $DIRS; do
+              # Trim whitespace introduced by JSON formatting
+              dir="${dir#"${dir%%[![:space:]]*}"}"
+              dir="${dir%"${dir##*[![:space:]]}"}"
+              # PHPUnit 12 validates is_dir() strictly: emit <file> for .php entries, <directory> otherwise
+              case "$dir" in
+                *.php) echo "  <file>$dir</file>" ;;
+                *)     echo "  <directory>$dir</directory>" ;;
+              esac
+            done
             echo "  <exclude>testsuite/Magento/IntegrationTest.php</exclude>"
             echo "</testsuite>"
           )


### PR DESCRIPTION
## Summary
- The matrix sharder injects an entry per shard into the generated `Mage-OS Suite` testsuite. `STANDALONE_TESTS` shards are single `.php` files (e.g. `./testsuite/Magento/Catalog/Model/CategoryTest.php`), but the loop unconditionally wrapped every entry in `<directory>...</directory>`.
- PHPUnit 12 added strict `is_dir()` validation on `<directory>` paths, so the file-as-directory entries now fail the suite definition.
- Branch on the `.php` suffix to emit `<file>` for those entries and keep `<directory>` for everything else. Also trim any whitespace the JSON formatting may leave around each entry before the check.

## Test plan
- [ ] CI: `Full Integration Tests` workflow runs without PHPUnit configuration errors on the standalone-test shards (e.g. `MassScheduleTest.php`, `CategoryTest.php`).
- [ ] Inspect the workflow `Debug:` output for `NEW_TESTSUITE_ENTRY` and confirm `.php` shards appear as `<file>` and directory shards remain `<directory>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)