### PR TITLE
fix(workflows): exclude abstract test base classes from Mage-OS suite

### DIFF
--- a/.github/workflows/full-integration-tests.yaml
+++ b/.github/workflows/full-integration-tests.yaml
@@ -235,6 +235,22 @@ jobs:
               esac
             done
             echo "  <exclude>testsuite/Magento/IntegrationTest.php</exclude>"
+            # PHPUnit 12 treats abstract test classes discovered via <directory> as runner
+            # warnings (exit 1). Exclude any Abstract*Test.php files inside the included
+            # shards so only concrete tests load.
+            IFS=','
+            for dir in $DIRS; do
+              dir="${dir#"${dir%%[![:space:]]*}"}"
+              dir="${dir%"${dir##*[![:space:]]}"}"
+              case "$dir" in
+                *.php) continue ;;
+              esac
+              if [ -d "$dir" ]; then
+                find "$dir" -type f -name 'Abstract*Test.php' -print | while read -r abs_test; do
+                  echo "  <exclude>$abs_test</exclude>"
+                done
+              fi
+            done
             echo "</testsuite>"
           )
           echo "Debug: $NEW_TESTSUITE_ENTRY"
@@ -243,7 +259,7 @@ jobs:
           
           ## TODO: I want to have a possibility to NOT ignore those test if I wish to - by adding additional input to github actions, for example
           sed -i '/<testsuites>/i\<groups>\<exclude>\<group>integrationIgnore<\/group><\/exclude><\/groups>' "$FILE"
-          echo "\nIgnore group `integrationIgnore` has been added to $FILE \n"
+          echo "\nIgnore group 'integrationIgnore' has been added to $FILE \n"
           
           cat $FILE;
 


### PR DESCRIPTION
## Summary
- PHPUnit 12 treats discovered `Abstract*Test.php` files as runner warnings ("Class ... is abstract"). The integration job interprets the resulting non-zero PHPUnit exit code as a failure even when every concrete test in the shard passes.
- In the most recent full integration run on `mage-os/mageos-magento2` (run [25978664094](https://github.com/mage-os/mageos-magento2/actions/runs/25978664094)), ~17 of 29 failed jobs are caused entirely by this — for example `TestModuleOverrideConfig`, `GraphQlCache`, `Customer`, `Swatches`, `Test (Integrity)`, `PaypalGraphQl`, `CatalogUrlRewrite`, `LayeredNavigation`, several `Catalog` shards, and the `Sales`/`Bundle` shards. Test output looks like `OK, but there were issues!`.
- This change generates `<exclude>` entries for any `Abstract*Test.php` inside the included `<directory>` shards so only concrete tests load. Single-file shards (`*.php` matrix entries) are skipped.
- Drive-by: the trailing `echo` for the `integrationIgnore` group had unescaped backticks, causing bash to execute `integrationIgnore` as a command and log `integrationIgnore: command not found` in every job. Quoted with single quotes.

## Test plan
- [ ] Re-run `Integration Tests - Full Test Suite` on a branch of `mage-os/mageos-magento2` (e.g. `release/3.x`) and confirm the previously-failing abstract-only jobs now pass.
- [ ] Confirm the `Run Integration Tests for Modules` step no longer logs `integrationIgnore: command not found`.
- [ ] Verify the generated `phpunit.xml.dist` (printed by `cat $FILE`) includes `<exclude>` entries for the expected Abstract*Test.php files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)