### PR TITLE
fix(workflows): also exclude *AbstractTest.php suffix from Mage-OS suite

### DIFF
--- a/.github/workflows/full-integration-tests.yaml
+++ b/.github/workflows/full-integration-tests.yaml
@@ -236,8 +236,8 @@ jobs:
             done
             echo "  <exclude>testsuite/Magento/IntegrationTest.php</exclude>"
             # PHPUnit 12 treats abstract test classes discovered via <directory> as runner
-            # warnings (exit 1). Exclude any Abstract*Test.php files inside the included
-            # shards so only concrete tests load.
+            # warnings (exit 1). Exclude any Abstract*Test.php or *AbstractTest.php files
+            # inside the included shards so only concrete tests load.
             IFS=','
             for dir in $DIRS; do
               dir="${dir#"${dir%%[![:space:]]*}"}"
@@ -246,7 +246,7 @@ jobs:
                 *.php) continue ;;
               esac
               if [ -d "$dir" ]; then
-                find "$dir" -type f -name 'Abstract*Test.php' -print | while read -r abs_test; do
+                find "$dir" -type f \( -name 'Abstract*Test.php' -o -name '*AbstractTest.php' \) -print | while read -r abs_test; do
                   echo "  <exclude>$abs_test</exclude>"
                 done
               fi

--- a/.github/workflows/full-integration-tests.yaml
+++ b/.github/workflows/full-integration-tests.yaml
@@ -235,6 +235,22 @@ jobs:
               esac
             done
             echo "  <exclude>testsuite/Magento/IntegrationTest.php</exclude>"
+            # PHPUnit 12 treats abstract test classes discovered via <directory> as runner
+            # warnings (exit 1). Exclude any Abstract*Test.php files inside the included
+            # shards so only concrete tests load.
+            IFS=','
+            for dir in $DIRS; do
+              dir="${dir#"${dir%%[![:space:]]*}"}"
+              dir="${dir%"${dir##*[![:space:]]}"}"
+              case "$dir" in
+                *.php) continue ;;
+              esac
+              if [ -d "$dir" ]; then
+                find "$dir" -type f -name 'Abstract*Test.php' -print | while read -r abs_test; do
+                  echo "  <exclude>$abs_test</exclude>"
+                done
+              fi
+            done
             echo "</testsuite>"
           )
           echo "Debug: $NEW_TESTSUITE_ENTRY"
@@ -243,7 +259,7 @@ jobs:
           
           ## TODO: I want to have a possibility to NOT ignore those test if I wish to - by adding additional input to github actions, for example
           sed -i '/<testsuites>/i\<groups>\<exclude>\<group>integrationIgnore<\/group><\/exclude><\/groups>' "$FILE"
-          echo "\nIgnore group `integrationIgnore` has been added to $FILE \n"
+          echo "\nIgnore group 'integrationIgnore' has been added to $FILE \n"
           
           cat $FILE;
 


### PR DESCRIPTION
## Summary

Extends the abstract-test exclusion in `full-integration-tests.yaml` to also match the suffix form `*AbstractTest.php`. The prior commit only handled the `Abstract*Test.php` prefix form.

## Why

PHPUnit 12 treats abstract test classes discovered via `<directory>` as runner warnings, which the integration job interprets as exit code 1 — turning shards red even when all concrete tests pass.

Upstream Magento ships 6 abstract base classes with the suffix form that the previous glob missed:

- `dev/tests/integration/testsuite/Magento/PaypalGraphQl/PaypalExpressAbstractTest.php`
- `dev/tests/integration/testsuite/Magento/PaypalGraphQl/PaypalPayflowProAbstractTest.php`
- `dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/EntityAbstractTest.php`
- `dev/tests/integration/testsuite/Magento/ImportExport/Model/Export/EntityAbstractTest.php`
- `dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/EntityAbstractTest.php`
- `dev/tests/integration/testsuite/Magento/ImportExport/Model/Import/Entity/EavAbstractTest.php`

These were the root cause of 14 of the 21 red shards in mage-os/mageos-magento2 run 25980469684 (release/3.x full integration suite).

## Change

```diff
- find "$dir" -type f -name 'Abstract*Test.php' -print
+ find "$dir" -type f \( -name 'Abstract*Test.php' -o -name '*AbstractTest.php' \) -print
```

## Test plan

- [ ] Re-run the full integration test suite on `release/3.x` of `mageos-magento2` after merge and confirm the 14 abstract-warning shards turn green.