### PR TITLE
fix(workflows): filter abstract test base classes out of matrix shards

### DIFF
--- a/.github/workflows/full-integration-tests.yaml
+++ b/.github/workflows/full-integration-tests.yaml
@@ -115,6 +115,8 @@ jobs:
           
           # Handle exclusion list
           # run over EXCLUSION_LIST, find all "*Test.php" files, and put them in array. Exclude directories.
+          # Skip abstract test base classes (Abstract*Test.php / *AbstractTest.php) — PHPUnit 12
+          # treats loading an abstract class as a runner warning, which produces exit 1.
           EXCLUSION_LIST_FILES=()
           for dir in "${EXCLUSION_LIST[@]}"; do
             while IFS= read -r -d '' file; do
@@ -123,7 +125,8 @@ jobs:
                   continue
                 fi
                 EXCLUSION_LIST_FILES+=("$file")
-            done < <(find "$dir" -mindepth 1 -type f -name '*Test.php' -print0)
+            done < <(find "$dir" -mindepth 1 -type f -name '*Test.php' \
+              ! -name 'Abstract*Test.php' ! -name '*AbstractTest.php' -print0)
           done
           
           ## run over EXCLUSION_LIST_FILES and call add_dir_to_line for each file


### PR DESCRIPTION
## Summary

Follow-up to #372 / #373 / #374.

The "Create Mage-OS testsuite" step already excludes `Abstract*Test.php` / `*AbstractTest.php` files when they are discovered under a `<directory>` entry. But the `EXCLUSION_LIST` modules (`Catalog`, `Bundle`, `Sales`, `AsynchronousOperations`) are pre-expanded in `matrix-calculator` into comma-separated lists of individual `*.php` files, which the testsuite step emits as `<file>` entries — bypassing the directory-side filter.

Result: the [latest full-suite run](https://github.com/mage-os/mageos-magento2/actions/runs/25981579856) still has 13 shards failing solely because PHPUnit 12 emits a runner warning for loading an abstract class, which produces exit 1:

- Catalog shards (jobs 76371189497, 505, 508, 511, 515, 535, 555, 569) — `AbstractSaveAttributeTest`, `AbstractDeleteAttributeControllerTest`, `AbstractAlertTest`, `AbstractRelationsDataProviderTest`, `AbstractEavTest`, `AbstractAttributeTest`, `AbstractCurrencyTest`, `AbstractRenderCustomOptionsTest`, `AbstractUpdateAttributeTest`, `AbstractLinksTest`
- Bundle shards (jobs 76371189528, 541) — `AbstractBundleOptionsViewTest`, `AbstractBundleProductSaveTest`
- Sales shards (jobs 76371189542, 547, 556) — `AbstractAddressFormTest`, `AbstractInvoiceControllerTest`, `AbstractCollectorPositionsTest`

All are EXCLUSION_LIST modules — confirmed not a coincidence.

## Fix

Add `! -name 'Abstract*Test.php' ! -name '*AbstractTest.php'` to the `find` in `EXCLUSION_LIST_FILES` so abstract base classes never enter the matrix in the first place. The directory-side exclude loop in the testsuite-generation step remains authoritative for non-EXCLUSION_LIST shards — both layers stay complementary, not duplicate.

## Test plan

- [ ] Trigger `Integration Tests - Full Test Suite` workflow_dispatch against a Magento 2 head
- [ ] Confirm previously-failing Catalog / Bundle / Sales shards now exit 0
- [ ] Confirm no shard skips concrete tests that previously ran

🤖 Generated with [Claude Code](https://claude.com/claude-code)