### PR TITLE
Fix cache key in nx-integration-tests using undefined inputs.ref

### DIFF
--- a/.github/workflows/nx-integration-tests.yml
+++ b/.github/workflows/nx-integration-tests.yml
@@ -111,7 +111,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: main
-          key: ${{ runner.os }}-project-${{ inputs.ref }}
+          key: ${{ runner.os }}-project-${{ inputs.pr_head }}
       
       # could probably swap this to a docker container in future
       - name: Install NX


### PR DESCRIPTION
## Summary

The `integration-tests` job in `nx-integration-tests.yml` restores the project cache with:

```yaml
key: ${{ runner.os }}-project-${{ inputs.ref }}
```

But `inputs.ref` is **not a defined input** for this workflow — the declared inputs are `repository`, `pr_head`, and `pr_base`. The expression resolves to an empty string on every run, producing the cache key `Linux-project-`, which never matches the entry saved by the `nx-project-setup` job (which correctly uses `inputs.pr_head` as the ref throughout).

**Effect:** guaranteed cache miss on any fresh PR run. The `./main` directory is empty when the `integration-tests` job starts, the PHPUnit bootstrap falls back to running `setup:install` against a `tmp-mysql` container that was never initialised, and the entire suite crashes at bootstrap before a single test executes. The failure looks like a code or infrastructure problem but is purely a missing cache hit.

This explains why integration tests pass when a warm cache happens to be present on the runner (the key `Linux-project-` accidentally matches a stale entry) but fail consistently on new or retargeted PRs.

## Fix

Replace `inputs.ref` with `inputs.pr_head`, consistent with every other place in this workflow that references the head SHA.

## Test plan

- [ ] Open a fresh PR against `mageos-magento2` — integration-tests job should now find the cache saved by `nx-project-setup` and proceed past bootstrap