### PR TITLE
Run Nx integration tests sequentially to prevent shared-sandbox race condition

### DIFF
--- a/.github/workflows/nx-integration-tests.yml
+++ b/.github/workflows/nx-integration-tests.yml
@@ -153,4 +153,4 @@ jobs:
         working-directory: ./main
         run: |
           export WARDEN="$(dirname $(pwd))/warden/bin/warden"
-          nx affected --target=test:integration --head=HEAD --base=remotes/origin/${{ inputs.pr_base }}
+          nx affected --target=test:integration --head=HEAD --base=remotes/origin/${{ inputs.pr_base }} --parallel=1


### PR DESCRIPTION
## Problem

When Nx runs multiple affected projects in parallel (default `--parallel=3`), each project's PHPUnit bootstrap runs concurrently inside the **same Warden `php-fpm` container**, sharing the same bind-mounted filesystem. This produces two classes of race condition that crash the integration test bootstrap before any tests execute:

### 1. `deployTestModules.php` conflicts

Both bootstraps call `deployTestModules.php` simultaneously. Each process removes and re-copies to `app/code/Magento/TestModule*/` at the same time — one process deletes directories the other just created, or two `mkdir()` calls collide on the same path, triggering a `"File exists"` PHP warning that the integration test error handler converts into a fatal `PHPUnit\Framework\Exception`.

### 2. Shared sandbox directory conflict

Both bootstraps call `setup:install` via `Magento\TestFramework\Application::install()`, which creates a sandbox directory under:
```
dev/tests/integration/tmp/sandbox-0-<sha256(sha1(install-config))>/
```
Because both targets share the **same** `phpunit.xml.dist` and `install-config-mysql.php`, they compute an **identical** sandbox path. The second process to call `mkdir()` on that path fails with `"File exists"`, again converted to a fatal bootstrap exception.

## Fix

Add `--parallel=1` to the `nx affected` command so test targets execute sequentially:

```diff
-nx affected --target=test:integration --head=HEAD --base=remotes/origin/${{ inputs.pr_base }}
+nx affected --target=test:integration --head=HEAD --base=remotes/origin/${{ inputs.pr_base }} --parallel=1
```

## Trade-off

Sequential execution increases wall-clock time when multiple packages are affected simultaneously. However:

- Most PRs touch 1–2 packages, so the practical impact is small.
- The Warden stack (DB, Redis, RabbitMQ, OpenSearch) is a shared resource anyway, so true parallelism offers limited speed benefit.
- The tests were failing entirely without this change — reliability over speed.

A longer-term fix would give each test target a distinct install config (different DB name), producing unique sandbox paths and eliminating the shared-state problem while restoring parallelism.

## Related

Follows #379 (cache key fix, already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)