### PR TITLE
fix(nx): exclude abstract test base classes from Nx integration test suite

### DIFF
--- a/nx-integration-tests-setup/action.yml
+++ b/nx-integration-tests-setup/action.yml
@@ -111,6 +111,35 @@ runs:
         nx print-affected --head=HEAD --base=remotes/origin/${{ inputs.pr_base }} > ${AFFECTED_OUTPUT}
         echo "Affected Projects: $(jq .projects ${AFFECTED_OUTPUT})"
     
+    - name: Exclude abstract test base classes from phpunit.xml.dist
+      working-directory: ./main
+      shell: bash
+      run: |
+        # PHPUnit 12 emits a runner warning for abstract classes whose filename ends
+        # in Test.php, producing exit code 2 which Nx treats as failure.
+        # Mirror the find-based filter from the full-suite workflow (see PR #375).
+        PHPUNIT_CONFIG=dev/tests/integration/phpunit.xml.dist
+        TMPFILE=$(mktemp)
+
+        find dev/tests/integration/testsuite -type f \
+          \( -name 'Abstract*Test.php' -o -name '*AbstractTest.php' \) \
+          -print0 | sort -z | while IFS= read -r -d '' file; do
+            rel="${file#dev/tests/integration/}"
+            printf '            <exclude>%s</exclude>\n' "${rel}"
+          done > "${TMPFILE}"
+
+        awk -v excludes="${TMPFILE}" '
+          /Magento Integration Tests Real Suite/ { in_suite=1 }
+          in_suite && /<\/testsuite>/ {
+            while ((getline line < excludes) > 0) print line
+            in_suite=0
+          }
+          { print }
+        ' "${PHPUNIT_CONFIG}" > "${PHPUNIT_CONFIG}.tmp" \
+          && mv "${PHPUNIT_CONFIG}.tmp" "${PHPUNIT_CONFIG}"
+
+        rm "${TMPFILE}"
+
     - name: Project Cache
       uses: actions/cache/save@v3
       with:


### PR DESCRIPTION
## Summary

Follow-up to #375, porting the same fix to the Nx integration test setup.

PHPUnit 12 emits a runner warning for every abstract class whose filename ends in `Test.php`, causing exit code 2 which Nx treats as failure even when all real tests pass. This was surfaced while working on mage-os/mageos-magento2#213.

At setup time, `find` discovers all `Abstract*Test.php` / `*AbstractTest.php` files in the testsuite directory and `awk` injects `<exclude>` entries into `phpunit.xml.dist` for the `Magento Integration Tests Real Suite`. The patched file is saved into the project cache so all matrix runners pick it up without repeating the work.

## Test plan

- [ ] Trigger the Nx integration test workflow against a PR that affects modules with no abstract test files — confirm exit 0
- [ ] Trigger against a PR affecting modules whose testsuite directory contains abstract test base classes — confirm exit 0 and no PHPUnit runner warnings in the output